### PR TITLE
major(build) ARM builds deprecated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @ryakel will be requested for review when someone 
+# opens a pull request.
+*       @ryakel

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -78,7 +78,7 @@ jobs:
           context: .
           push: true
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -94,7 +94,7 @@ jobs:
           context: .
           push: true
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,7 +83,7 @@ jobs:
           context: .
           push: true
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -99,7 +99,7 @@ jobs:
           context: .
           push: true
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag_version.outputs.new_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.19-alpine
+FROM python:3.12-alpine
 LABEL maintainer="github.com/ryakel"
 
 # Copy requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.19-alpine
 LABEL maintainer="github.com/ryakel"
 
 # Copy requirements

--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ The following **Linux** architectures supported by this image are:
 
 | Architectures | Tag |
 | :----: | --- |
-| 386<br>amd64<br>armv7<br>arm64 | latest |
-| 386<br>amd64<br>armv7<br>arm64  | dev |
+| 386<br>amd64 | latest |
+| 386<br>amd64 | dev |
+| armv7 (deprecated)<br>arm64 (deprecated) | ≤ 0.3.30 |
+
+:warning: ARM builds have been deprecated as of v0.3.30. No further development is expected on them going forward. :warning:
 
 ## Version Tags
 
-| Tag | Description |
+| Tag | Desc⚠️ription |
 | :----: | --- |
 | latest | Current release code |
 | dev | Pre-release code for testing issues |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following **Linux** architectures supported by this image are:
 
 ## Version Tags
 
-| Tag | Desc⚠️ription |
+| Tag | Description |
 | :----: | --- |
 | latest | Current release code |
 | dev | Pre-release code for testing issues |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ The following table outlines the currently-supported versions
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.x   | :white_check_mark: |
-| < 0.3   | :x:                |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows the Angular guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
No longer building ARM images

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Due to non-use and significantly longer build times to support, ARM builds have been deprecated in v0.4. The last available ARM build is v0.3.30. 