### PR TITLE
feat(build): deprecate old sonarr-yt-dlp repo

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -83,7 +83,6 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -102,8 +101,6 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag_version.outputs.new_tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag_version.outputs.new_tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,7 +88,6 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -107,8 +106,6 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag.outputs.tag }}
-            ${{ secrets.DOCKER_USERNAME }}/sonarr-yt-dlp:${{ steps.tag_version.outputs.new_tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag.outputs.tag }}
             ${{ secrets.DOCKER_USERNAME }}/stream-harvestarr:${{ steps.tag_version.outputs.new_tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 ![Screen Harvester logo](/img/stream-harvestarr-logo_small.png)
 # Stream Harvestarr by [@ryakel](https://github.com/ryakel)
 
-![Docker Build](https://img.shields.io/docker/cloud/automated/ryakel/stream-harvestarr?style=flat-square)
 ![Docker Pulls](https://img.shields.io/docker/pulls/ryakel/stream-harvestarr?style=flat-square)
 ![Docker Stars](https://img.shields.io/docker/stars/ryakel/stream-harvestarr?style=flat-square)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Docker Hub](https://img.shields.io/badge/Open%20On-DockerHub-blue)](https://hub.docker.com/r/ryakel/stream-harvestarr)
 
 :warning: NOTE: The image name and repo have changed to ```ryakel/stream-havestarr```. 
-```ryakel/sonarr-yt-dlp``` will continue to be updated for now, but will be deprecated in the near future. 
+```ryakel/sonarr-yt-dlp``` has been deprecated as of version ```1.2.17```. 
 Please update your image and update your config.yml. :warning:
 
 [ryakel/stream-harvestarr](https://github.com/ryakel/stream-harvestarr) is a [Sonarr](https://sonarr.tv/) companion script to allow the automatic downloading of web series normally not available for Sonarr to search for. Using [YT-DLP](https://github.com/yt-dlp/yt-dlp) (a youtube-dl fork with added features) it allows you to download your webseries from the list of [supported sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows the Angular guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
**BREAKING CHANGE**: sonarr-yt-dlp image has been deprecated as of ```v1.2.17```. Please migrate to ```stream-harvestarr``` image

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- It must start with BREAKING CHANGE: -->


## Other information
