### PR TITLE
feat(app): feature additions

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -12,6 +12,8 @@ sonarr:
 ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection
     default_format: bestvideo[width<=1920]+bestaudio/best[width<=1920]
+    merge_output_format: "mkv"  # Valid options are avi, flv, mkv, mov, mp4, webm
+    
 series:
   # Standard channel to check
   - title: Smarter Every Day

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -384,8 +384,17 @@ class StreamHarvester(object):
                                 ),
                                 'progress_hooks': [ytdl_hooks],
                                 'noplaylist': True,
+                                'forceipv4': True,
+                                'sleep_interval': 5,
+                                'max_sleep_interval': 30,
+                                'nocontinue': True,
+                                'nooverwrites': True,
+                                'throttled_rate': '100K',
+                                'concurrent_fragments': 5,
                             }
+
                             ytdl_format_options = self.appendcookie(ytdl_format_options, cookies)
+                            
                             if 'format' in ser:
                                 ytdl_format_options = self.customformat(ytdl_format_options, ser['format'])
                             if 'subtitles' in ser:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -90,6 +90,12 @@ class StreamHarvester(object):
         except Exception:
             sys.exit("Error with series config.yml values.")
 
+        # Merge output format
+        try:
+            self.ytdl_merge_output_format = cfg["ytdl"]["merge_output_format"]
+        except Exception:
+            sys.exit("Error with ytdl config.yml values.")
+
     def get_episodes_by_series_id(self, series_id):
         """Returns all episodes for the given series"""
         logger.debug('Begin call Sonarr for all episodes for series_id: {}'.format(series_id))
@@ -368,7 +374,7 @@ class StreamHarvester(object):
                             ytdl_format_options = {
                                 'format': self.ytdl_format,
                                 'quiet': True,
-                                'merge-output-format': 'mp4',
+                                "merge_output_format": self.ytdl_merge_output_format,
                                 'outtmpl': '/sonarr_root{0}/Season {1}/{2} - S{1}E{3} - {4} WEBDL.%(ext)s'.format(
                                     ser['path'],
                                     eps['seasonNumber'],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows the Angular guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
* ✨ Allow choosing output format
* 🐛 Fix parameter name
* 👕 Use double-quotes

### TheFrenchGhosty additions
* 🔧 foreceipv4
* * Tell yt-dlp to use IPv4, needed because lots of hosting and VPNs providers don't support IPv6.
* 🔧 sleep_interval
* * Tell yt-dlp to pause between 5 and 30 seconds between 2 download to avoid getting "429 - Too Many Requests". (Original idea by BioSchokoMuffin).
* 🔧 nocontinue
* * Tell yt-dlp not to resume partially downloaded files and to restart from the beginning (Mainly to avoid corruption)
* 🔧 nooverwrites
* * Tell yt-dlp not to overwrite existing files (Useful when metadata has already been downloaded)
* 🔧 throttled_rate
* * For age-gated videos that are detected to be throttled, it will restart the download.
* 🔧 concurrent-fragments
* * Set the number of dash/hls native fragments to 5 concurrent download to speed things up.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- It must start with BREAKING CHANGE: -->


## Other information
