### PR TITLE
Potential fix for code scanning alert no. 15: Clear-text logging of sensitive information

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -56,7 +56,7 @@ jobs:
       # https://github.com/ncipollo/release-action 
       - name: Create a GitHub release
         if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.15.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -56,7 +56,7 @@ jobs:
       # https://github.com/ncipollo/release-action 
       - name: Create a GitHub release
         if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.15.0
+        uses: ncipollo/release-action@v1.16.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,7 @@ jobs:
       # https://github.com/ncipollo/release-action 
       - name: Create a GitHub release
         if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.15.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,7 @@ jobs:
       # https://github.com/ncipollo/release-action 
       - name: Create a GitHub release
         if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.15.0
+        uses: ncipollo/release-action@v1.16.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.13-alpine
 LABEL maintainer="github.com/ryakel"
 LABEL org.opencontainers.image.source="https://github.com/ryakel/stream-harvestarr"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please update your image and update your config.yml. :warning:
 ## How do I use it
 
 1. Firstly you need a series that is available online in the supported sites that YouTube-DL can grab from.
-1. Secondly you need to add this to Sonarr and monitor the episodes that you want.
+1. Secondly you need to add the series to Sonarr (the way you would any other) and monitor the episodes that you want.
 1. Thirdly edit your config.yml accordingly so that this knows where your Sonarr is, which series you are after and where to grab it from.
 1. Lastly be aware that this requires the TVDB to match exactly what the episodes titles are in the scan, generally this is ok but as its an openly editable site sometime there can be differences.
 

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -408,7 +408,16 @@ class StreamHarvester(object):
                                     'progress_hooks': [ytdl_hooks_debug],
                                 })
                                 logger.debug('yt-dlp opts used for downloading')
-                                logger.debug(ytdl_format_options)
+                                # Redact potentially sensitive keys before logging
+                                def _redact_sensitive(d, keys=('apikey', 'cookie', 'cookies', 'cookies_file')):
+                                    safe = {}
+                                    for k, v in d.items():
+                                        if any(s in k.lower() for s in keys):
+                                            safe[k] = '***REDACTED***'
+                                        else:
+                                            safe[k] = v
+                                    return safe
+                                logger.debug(_redact_sensitive(ytdl_format_options))
                             try:
                                 with yt_dlp.YoutubeDL(ytdl_format_options) as ydl:
                                      ydl.download([dlurl])


### PR DESCRIPTION
Potential fix for [https://github.com/ryakel/stream-harvestarr/security/code-scanning/15](https://github.com/ryakel/stream-harvestarr/security/code-scanning/15)

The best way to fix this problem is to ensure that sensitive information, such as API keys and passwords, are never included in log statements. In this context, rather than logging the entire `ytdl_format_options` dictionary, you should log only the non-sensitive fields, or redact fields that could contain sensitive information before logging. Specifically, in line 411 within `download`, replace `logger.debug(ytdl_format_options)` with a version that filters out or masks any sensitive values (like 'apikey', 'cookies', etc.), or logs only a subset of safe keys. You may do this by creating a new dictionary containing only whitelisted keys, or using a helper method to redact potentially sensitive entries.

Implementation steps:
- In `download` method, replace the debug log of the full dictionary with a safe-logging version.
- Either mask/redact potential sensitive values within `ytdl_format_options`, or construct a filtered dictionary for logging.
- Optionally, add a helper function to redact dictionary values based on key names.
- No extra package imports are needed; standard Python is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
