### PR TITLE
fix(docker): install deno runtime and yt-dlp-ejs for YouTube extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ LABEL org.opencontainers.image.source="https://github.com/ryakel/stream-harvesta
 # Copy requirements
 COPY requirements.txt requirements.txt
 
-# Update and install ffmpeg and requirements
+# Update and install ffmpeg, deno (JS runtime for yt-dlp YouTube extraction) and requirements
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
-    apk add --no-cache ffmpeg curl alpine-sdk && \
+    apk add --no-cache ffmpeg curl deno alpine-sdk && \
     pip3 install --upgrade pip && \
     pip3 install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests>=2.32.3
 yt-dlp>=2025.1.27
+yt-dlp-ejs
 pyyaml>=6.0.2
 schedule>=1.2.2
 fuzzywuzzy>=0.18.0


### PR DESCRIPTION
yt-dlp now requires a JavaScript runtime to extract some YouTube formats.
Without one, yt-dlp emits "No supported JavaScript runtime could be found"
and downloads fail with "No video_url" errors. Install deno via apk and
add yt-dlp-ejs so the default runtime is picked up automatically.

Fixes #96