### PR TITLE
fix(ci): checkout source before refreshing Docker Hub README

### DIFF
--- a/.github/workflows/_build-and-publish.yaml
+++ b/.github/workflows/_build-and-publish.yaml
@@ -142,6 +142,13 @@ jobs:
     needs: [build, smoke-test]
     runs-on: ubuntu-latest
     steps:
+      # peter-evans/dockerhub-description reads ./README.md from the
+      # working directory; without checkout it fails with ENOENT. Skipped
+      # for the dev/non-readme path since regctl doesn't need the source.
+      - name: Checkout
+        if: ${{ inputs.update_dockerhub_description }}
+        uses: actions/checkout@v6
+
       - name: Login to GHCR
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary
Fixes the `Update Docker Hub description` step that failed on the v1.6.26 publish run with `ENOENT: no such file or directory, open './README.md'`.

The `replicate` job in `_build-and-publish.yaml` has no `actions/checkout` step (regctl doesn't need source). When `peter-evans/dockerhub-description` runs, it tries to read `./README.md` from the working directory and fails. Adds a conditional checkout step gated on `inputs.update_dockerhub_description` so the dev path keeps its lighter footprint.

## Impact of the bug (and what wasn't broken)
- Image publish on `v1.6.26`: ✅ succeeded. `:latest` and `:v1.6.26` are correctly on GHCR + Docker Hub with matching digests.
- Docker Hub README: stale — didn't get refreshed this release. This PR fixes the next run.
- Dev pushes were never affected (`update_dockerhub_description: false` on dev).

## Test plan
- [ ] PR canary green.
- [ ] After dev merge: replicate job runs without README refresh (no checkout, no peter-evans step) — confirms the conditional works for the dev path.
- [ ] After main merge: replicate job runs WITH checkout, peter-evans/dockerhub-description succeeds, Docker Hub page reflects current README.md.

https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9

---
_Generated by [Claude Code](https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9)_