### PR TITLE
Promote Docker Hub README ENOENT fix to main

### DIFF
--- a/.github/workflows/_build-and-publish.yaml
+++ b/.github/workflows/_build-and-publish.yaml
@@ -142,6 +142,13 @@ jobs:
     needs: [build, smoke-test]
     runs-on: ubuntu-latest
     steps:
+      # peter-evans/dockerhub-description reads ./README.md from the
+      # working directory; without checkout it fails with ENOENT. Skipped
+      # for the dev/non-readme path since regctl doesn't need the source.
+      - name: Checkout
+        if: ${{ inputs.update_dockerhub_description }}
+        uses: actions/checkout@v6
+
       - name: Login to GHCR
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary
Promotes the Docker Hub README ENOENT hotfix from `development` to `main`. The fix adds a conditional `actions/checkout@v6` step to the `replicate` job in `_build-and-publish.yaml`, gated on `inputs.update_dockerhub_description`. Without it, `peter-evans/dockerhub-description` failed with `ENOENT: no such file or directory, open './README.md'` on the v1.6.26 publish.

Verified clean on dev publish `43f231b` — all 6 checks green, replicate step still skips checkout on the dev path (where `update_dockerhub_description: false`).

## Expected outcome on merge
- Auto-bump to `v1.6.27` (patch).
- New GitHub release.
- Publish to GHCR + Docker Hub `:latest` and `:v1.6.27`.
- **Docker Hub description refresh succeeds this time** — the failure mode this PR addresses.

## Test plan
- [ ] Replicate job runs to completion (not 19s-ENOENT-fail like v1.6.26).
- [ ] `Update Docker Hub description` step succeeds.
- [ ] Docker Hub repo page reflects current README.md.
- [ ] `:latest` and `:v1.6.27` digests match between GHCR and Docker Hub.

https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9

---
_Generated by [Claude Code](https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9)_