### PR TITLE
Promote cron weekly-bump restore to main

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -33,12 +33,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_release_rules: major:major,breaking:major,minor:minor,patch:patch,fix:patch
-          # Only bump if commits since last tag warrant it. Without this, the
-          # weekly schedule cuts an empty-changelog release every Wednesday
-          # even when nothing has changed. The build still runs (it depends
-          # only on `prepare`) so :latest still picks up base-image security
-          # updates -- it just won't get a new vX.Y.Z tag from the rebake.
-          default_bump: false
+          # Bump every weekly run -- the *rebake itself* is the release.
+          # yt-dlp ships frequently to chase YouTube changes; Alpine ships
+          # base-image security patches; pip resolves >= constraints to
+          # whatever's current. Each Wednesday's image is genuinely
+          # different content even with no source changes, and a new
+          # vX.Y.Z lets users pin / roll back to a known-good week.
+          default_bump: patch
 
       - name: Create a GitHub release
         if: steps.tag_version.outputs.new_tag != ''
@@ -46,7 +47,18 @@ jobs:
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          body: |
+            Weekly maintenance rebake. No source changes since last release.
+
+            Picks up whatever's current upstream:
+            - `python:3.14-alpine` base image (security patches)
+            - Alpine packages (ffmpeg, curl, deno, nodejs)
+            - Python deps satisfying current `requirements.txt` constraints
+              (notably yt-dlp, which ships frequently to track YouTube changes)
+
+            Pin to this tag for reproducibility, or follow `:latest` to track weekly.
+
+            ${{ steps.tag_version.outputs.changelog }}
 
   build-and-publish:
     name: Build and publish


### PR DESCRIPTION
## Summary
**Item A** from the cron design discussion. Promotes the weekly version-bump restore from dev to main.

Reverts `default_bump: false` (set in #100) back to `patch` so each Wednesday's cron rebake cuts a real `vX.Y.Z` tag and GitHub release. Custom release body explains "this is a maintenance rebake" so the release page isn't a wall of empty changelogs. Verified clean on dev (`dfd4796`).

This is the foundation for **Item C** (`:rc` → `:latest` Wed/Thu split), coming next as a separate PR.

## Expected outcome on merge
- Auto-bump to `v1.6.28` (patch). This is a *push-to-main* bump (using main.yaml's `mathieudutour` step), separate from the future weekly cron bumps.
- New GitHub release with auto-generated changelog.
- Publish to GHCR + Docker Hub `:latest` and `:v1.6.28`.
- Docker Hub README refresh (now confirmed working post-#103).

## Test plan
- [ ] Replicate job + README refresh succeed.
- [ ] `:latest` and `:v1.6.28` digests match between GHCR and Docker Hub.
- [ ] Next Wednesday's cron actually fires and produces a release with the new body template (deferred verification — schedule fires only on default branch).

https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9

---
_Generated by [Claude Code](https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9)_