### PR TITLE
ci(cron): split into Wed RC build + Thu promote :rc → :latest

### DIFF
--- a/.github/workflows/cron-build-rc.yaml
+++ b/.github/workflows/cron-build-rc.yaml
@@ -1,11 +1,21 @@
-name: Cron
+name: Cron - Weekly RC Build
 
-# Weekly rebuild against the default branch to pick up upstream base-image and
-# package security updates. Tag/release bookkeeping is owned by main.yaml.
+# Wednesday rebuild that publishes to :rc (release candidate). The Thursday
+# promotion workflow (cron-promote-rc.yaml) retags this digest to :latest
+# after a 24h soak window.
+#
+# Tag/release bookkeeping (vX.Y.Z + GitHub release) happens here on
+# Wednesday since the build is what creates the artifact; Thursday only
+# retags by digest. If Thursday's promotion is blocked or fails, the
+# release still exists and users can pull :rc or :vX.Y.Z directly.
+#
+# Note: GitHub `schedule:` triggers fire only against the default branch
+# (main), so this workflow always runs against main's HEAD. There is no
+# "cron on dev" -- by design.
 
 on:
   schedule:
-    - cron: '15 06 * * 3'
+    - cron: '15 06 * * 3'  # Wed 06:15 UTC
   workflow_dispatch:
 
 permissions:
@@ -14,7 +24,7 @@ permissions:
 
 jobs:
   prepare:
-    name: Prepare release metadata
+    name: Prepare RC release metadata
     runs-on: ubuntu-latest
     outputs:
       docker_tag: ${{ steps.tag.outputs.tag }}
@@ -25,7 +35,7 @@ jobs:
 
       - name: Set Docker tag
         id: tag
-        run: echo "tag=latest" >> "$GITHUB_OUTPUT"
+        run: echo "tag=rc" >> "$GITHUB_OUTPUT"
 
       - name: Bump version and push tag
         id: tag_version
@@ -33,12 +43,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_release_rules: major:major,breaking:major,minor:minor,patch:patch,fix:patch
-          # Bump every weekly run -- the *rebake itself* is the release.
-          # yt-dlp ships frequently to chase YouTube changes; Alpine ships
-          # base-image security patches; pip resolves >= constraints to
-          # whatever's current. Each Wednesday's image is genuinely
-          # different content even with no source changes, and a new
-          # vX.Y.Z lets users pin / roll back to a known-good week.
+          # Bump every weekly run -- the rebake itself is the release.
+          # See cron-restore-weekly-bump (#104) for rationale.
           default_bump: patch
 
       - name: Create a GitHub release
@@ -56,19 +62,22 @@ jobs:
             - Python deps satisfying current `requirements.txt` constraints
               (notably yt-dlp, which ships frequently to track YouTube changes)
 
-            Pin to this tag for reproducibility, or follow `:latest` to track weekly.
+            Currently published as `:rc` and `:${{ steps.tag_version.outputs.new_tag }}`.
+            Will be promoted to `:latest` on Thursday after the 24h soak window.
 
             ${{ steps.tag_version.outputs.changelog }}
 
   build-and-publish:
-    name: Build and publish
+    name: Build and publish RC
     needs: prepare
     uses: ./.github/workflows/_build-and-publish.yaml
     with:
       docker_tag: ${{ needs.prepare.outputs.docker_tag }}
       version_tag: ${{ needs.prepare.outputs.version_tag }}
       publish_to_dockerhub: true
-      update_dockerhub_description: true
+      # Defer Docker Hub README refresh until promotion to :latest. This
+      # build is :rc + :vX.Y.Z, not the user-facing latest.
+      update_dockerhub_description: false
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/cron-promote-rc.yaml
+++ b/.github/workflows/cron-promote-rc.yaml
@@ -1,0 +1,93 @@
+name: Cron - Promote RC to Latest
+
+# Thursday job that retags the GHCR :rc digest as :latest on both
+# registries via `regctl image copy` -- a manifest copy by digest, not
+# a rebuild. The bytes promoted to :latest are exactly what was built
+# and pushed by cron-build-rc.yaml ~24h earlier (the soak window).
+#
+# Future enhancement (Item B from the cron design discussion):
+# dead-man's-switch gate that requires a fresh "soak passed" signal
+# from a residential-IP runner before promoting. Until that signal
+# exists, this workflow promotes unconditionally on schedule. See
+# the Promotion gate step below for where the check goes.
+
+on:
+  schedule:
+    - cron: '15 06 * * 4'  # Thu 06:15 UTC (24h after cron-build-rc.yaml)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write        # GHCR push
+
+jobs:
+  promote:
+    name: Promote :rc to :latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # Required for peter-evans/dockerhub-description (reads ./README.md).
+        uses: actions/checkout@v6
+
+      - name: Promotion gate
+        # Placeholder for the dead-man's-switch (Item B). Once the
+        # residential-IP soak runner posts `LAST_SOAK_PASSED` to repo
+        # variables on each successful run, this step can check that
+        # the timestamp is within the freshness window (e.g. 30h)
+        # and exit non-zero otherwise. Today: pass-through.
+        run: |
+          if [ -n "${{ vars.LAST_SOAK_PASSED }}" ]; then
+            echo "::notice::soak signal present: ${{ vars.LAST_SOAK_PASSED }}"
+          else
+            echo "::notice::no soak signal configured -- promoting unconditionally (bootstrap mode)"
+          fi
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+
+      - name: Resolve :rc digest
+        id: digest
+        env:
+          REPO: ghcr.io/ryakel/stream-harvestarr
+        run: |
+          set -euo pipefail
+          if ! DIGEST=$(regctl image digest "${REPO}:rc" 2>/dev/null); then
+            echo "::error::no :rc tag found at ${REPO} -- did Wednesday's build run?"
+            exit 1
+          fi
+          echo "Resolved ${REPO}:rc -> ${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Promote :rc to :latest (GHCR + Docker Hub)
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: |
+          set -euo pipefail
+          SRC="ghcr.io/ryakel/stream-harvestarr@${DIGEST}"
+          echo "Copying ${SRC} -> ghcr.io/ryakel/stream-harvestarr:latest"
+          regctl image copy "${SRC}" "ghcr.io/ryakel/stream-harvestarr:latest"
+          echo "Copying ${SRC} -> docker.io/${DOCKER_USERNAME}/stream-harvestarr:latest"
+          regctl image copy "${SRC}" "docker.io/${DOCKER_USERNAME}/stream-harvestarr:latest"
+
+      - name: Refresh Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: ryakel/stream-harvestarr
+          enable-url-completion: true


### PR DESCRIPTION
## Summary
**Item C** from the cron design discussion. Splits the weekly cron into a Wed-build + Thu-promote pattern with `:rc` as the soak tag.

### Wednesday — `cron-build-rc.yaml` (rename of `cron.yaml`)
- Bumps version (`vX.Y.Z`), creates GitHub release.
- Builds multi-arch via `_build-and-publish.yaml`, publishes to GHCR + Docker Hub as `:rc` and `:vX.Y.Z`.
- Does **not** touch `:latest`.
- Does **not** refresh Docker Hub README (defer until promotion).

### Thursday — `cron-promote-rc.yaml` (new)
- Resolves `ghcr.io/ryakel/stream-harvestarr:rc` to a manifest digest.
- `regctl image copy` by digest → `:latest` on both registries. **No rebuild.** The bytes promoted are exactly what was built and pushed Wednesday.
- Refreshes Docker Hub README (now that `:latest` reflects this digest).

### Promotion gate (placeholder)
A `Promotion gate` step in the promote workflow shows where the dead-man's-switch check goes (Item B). Today it's a pass-through with a notice. When the residential-IP soak runner posts `LAST_SOAK_PASSED` as a repo variable, the gate can flip to fail-closed on stale signals.

## Constraint worth knowing
GitHub `schedule:` triggers fire only against the default branch (main). After this PR merges to main, both crons will run from main's HEAD on schedule — there's no "cron on dev." `workflow_dispatch` is enabled on both for manual triggering / testing.

## Test plan
- [ ] PR canary green.
- [ ] After dev merge: dev publish runs cleanly (cron itself doesn't fire from dev — schedule trigger only fires on default branch).
- [ ] After main merge: next Wednesday's `cron-build-rc.yaml` cuts a release and pushes `:rc` + `:vX.Y.Z` (deferred verification — Wed 06:15 UTC).
- [ ] Following Thursday: `cron-promote-rc.yaml` resolves the `:rc` digest and copies it to `:latest`.
- [ ] Optional immediate validation: trigger both via `workflow_dispatch` from the Actions UI to verify end-to-end without waiting a week.

## Out of scope
- The dead-man's-switch gate itself (Item B) — needs the home-side residential-IP soak runner first. Placeholder gate step is wired in.

https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9

---
_Generated by [Claude Code](https://claude.ai/code/session_012zv3zgaW7JeHUb9ajBz8v9)_