### PR TITLE
chore: claude bump-floors rule + apply to current floors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,36 @@ If a feature gap shows up for these arches, the response is to either
 (a) drop the arch from the publish matrix, or (b) carry a deno binary
 into the image manually. Don't paper over it with try/except in the
 Python code.
+
+## Dependency floor maintenance (Claude is the automation)
+
+`requirements.txt` uses `>=` floors. Dependabot is configured to yell
+when those floors drift below PyPI latest — that's intentional, don't
+disable it. The image always runs the absolute latest at build time
+(pip resolves `>=` to current); the floors are how we record what
+we've actually validated.
+
+**You (Claude) keep the floors current, not the pipeline.** Any time
+you touch code in this repo, run the bump check before you commit:
+
+```bash
+# Freshness: skip if requirements.txt was touched in the last 4 hours.
+last=$(git log -1 --format=%ct -- requirements.txt 2>/dev/null || echo 0)
+now=$(date +%s)
+if [ $(( now - last )) -lt 14400 ]; then
+    echo "requirements.txt is fresh; skipping bump."
+else
+    # For each `<pkg>>=<ver>` line, query
+    # https://pypi.org/pypi/<pkg>/json -> info.version and rewrite
+    # the floor when it differs.
+    for pkg in $(grep -oE '^[A-Za-z0-9_.-]+(?=>=)' requirements.txt); do
+        latest=$(curl -fsS "https://pypi.org/pypi/${pkg}/json" \
+                 | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
+        sed -i "s|^${pkg}>=.*|${pkg}>=${latest}|" requirements.txt
+    done
+fi
+```
+
+Land the bump as its own `chore(deps): bump requirements floors to
+PyPI latest` commit *before* the code change. If PyPI is unreachable,
+warn and continue with the existing floors — don't block progress.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests>=2.32.3
-yt-dlp>=2025.1.27
-yt-dlp-ejs
-pyyaml>=6.0.2
+requests>=2.33.1
+yt-dlp>=2026.3.17
+yt-dlp-ejs>=0.8.0
+pyyaml>=6.0.3
 schedule>=1.2.2
 fuzzywuzzy>=0.18.0
-Levenshtein>=0.27.0
+Levenshtein>=0.27.3


### PR DESCRIPTION
## Summary

Two changes in one PR:

1. **CLAUDE.md rule** (`090d39f`): documents that `>=` floor drift is a real signal (don't disable dependabot's drift warnings), and that Claude is responsible for bumping `requirements.txt` floors before code-touching commits — with a 4-hour freshness gate so it isn't run on every commit when a recent bump just landed.
2. **Floor bumps** (`2aa5c5b`): raises floors to PyPI latest, applying the rule from change 1. Closes the four open dependabot drift PRs:

   ```
   requests     2.32.3    -> 2.33.1
   yt-dlp       2025.1.27 -> 2026.3.17
   pyyaml       6.0.2     -> 6.0.3
   Levenshtein  0.27.0    -> 0.27.3
   ```

   Also pins a floor on `yt-dlp-ejs` (`>=0.8.0`) which was unpinned. `schedule` and `fuzzywuzzy` are already at latest.

## Test plan

- [ ] Smoke test on the resulting `:dev` build still passes (the bumped versions are what pip already resolved to during recent rebuilds via `>=`, so this is recording a tested fact, not speculating).
- [ ] After merge, dependabot's four drift PRs auto-close because there's nothing left to bump.