### PR TITLE
fix(ytsearch): pick first matching entry from yt-dlp playlist results

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -426,10 +426,12 @@ class StreamHarvester(object):
         else:
             video_url = None
             if 'entries' in result and len(result['entries']) > 0:
-                try:
-                    video_url = result['entries'][0].get('url')
-                except Exception as e:
-                    logger.error(e)
+                for entry in result['entries']:
+                    if entry is None:
+                        continue
+                    video_url = entry.get('url')
+                    if video_url:
+                        break
             else:
                 video_url = result.get('url')
             if playlist == video_url:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.33.1
+requests>=2.34.2
 yt-dlp>=2026.3.17
 yt-dlp-ejs>=0.8.0
 pyyaml>=6.0.3


### PR DESCRIPTION
## Summary

When `matchtitle` is set, yt-dlp keeps the playlist's full length but replaces every non-matching entry with `None`. `ytsearch` always read `entries[0]`, so any playlist whose target episode wasn't in slot 0 hit `AttributeError` on `None.get('url')`, swallowed it via the bare `except`, and reported `No video_url` — even though yt-dlp had already successfully extracted the matching entry further down the list.

Walk the entries and pick the first non-`None` one with a usable URL. Drop the swallowing `except` since the `None` case is now handled explicitly.

Also includes a routine `chore(deps)` floor bump (requests 2.33.1 → 2.34.2) per CLAUDE.md.

Fixes #114

## Test plan

- [ ] Point a Sonarr-managed series at a YouTube playlist where the matching episode is *not* the first entry, and confirm the episode downloads instead of erroring with `No video_url`.
- [ ] Confirm a single-video URL (no `entries`) still resolves via the `else` branch.
- [ ] Confirm a playlist with zero matching entries still logs `No video_url` and returns cleanly (no traceback).
- [ ] CI multi-arch build + YouTube smoke test green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Evbiy5SYmCKH75xsGmfbx)_