### PR TITLE
fix(ytsearch): read webpage_url from matched entry, not url

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,39 @@ All work follows: **feature branch → `development` → `main`**.
   Treat it as required — if it goes red, fix the image rather than
   merging around it.
 
+## yt-dlp playlist matching gotchas
+
+`ytsearch()` in `app/stream_harvestarr.py` calls
+`yt_dlp.YoutubeDL.extract_info(playlist_url, download=False)` with
+`matchtitle` set to a regex built from the Sonarr episode name. Two
+non-obvious behaviors bit us in issue #114:
+
+1. **Matched entries don't always have a top-level `url` field.** The
+   YouTube extractor sets `info_dict['webpage_url']` directly (the
+   canonical `https://www.youtube.com/watch?v=ID` URL) but `url` is
+   only populated when format selection picks a *single* non-merge
+   format. HLS videos — the default for modern YouTube uploads —
+   trigger ffmpeg audio+video merge; the merged "format" dict built
+   in `YoutubeDL._merge` has `requested_formats` but no top-level
+   `url`. After `info_dict.update(best_format)`, `entry.get('url')`
+   returns None even though extraction succeeded (m3u8 manifest
+   downloaded, deno JS challenge solved, etc.). Always read
+   `entry.get('webpage_url') or entry.get('url')` — the fallback is
+   there for non-YouTube extractors that only populate `url`.
+
+2. **Reading webpage_url means the downstream `download()` call
+   re-extracts.** The previous "working" path passed a direct
+   Googlevideo stream URL to the second `ydl.download([dlurl])` call,
+   which silently ignored the configured `format`,
+   `merge_output_format`, and subtitle postprocessors (those options
+   only apply when yt-dlp starts from a webpage URL, not a raw stream
+   URL). Passing the watch URL costs an extra ~5s extraction per
+   download but makes the user's format/subtitle config actually work
+   and avoids stale auth-token 403s when downloads queue up.
+
+If you ever feel tempted to "simplify" back to `.get('url')`, don't —
+re-read #114 first.
+
 ## Adding new architectures
 
 If a new platform is added to `main.yaml` / `cron.yaml`, also add it to

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -429,11 +429,11 @@ class StreamHarvester(object):
                 for entry in result['entries']:
                     if entry is None:
                         continue
-                    video_url = entry.get('url')
+                    video_url = entry.get('webpage_url') or entry.get('url')
                     if video_url:
                         break
             else:
-                video_url = result.get('url')
+                video_url = result.get('webpage_url') or result.get('url')
             if playlist == video_url:
                 return False, ''
             if video_url is None:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -425,6 +425,15 @@ class StreamHarvester(object):
             logger.error(e)
         else:
             video_url = None
+            # Prefer webpage_url over url: yt-dlp's YouTube extractor only sets
+            # url when format selection picks a single non-merge format. HLS
+            # videos (most modern YouTube uploads) trigger ffmpeg audio+video
+            # merge — the "merged format" dict (YoutubeDL._merge) has
+            # requested_formats but no top-level url, so info_dict.update gives
+            # us an entry with .get('url') == None even though extraction
+            # succeeded. webpage_url is always set by the YouTube extractor
+            # directly; the .get('url') fallback covers other extractors that
+            # only populate url. See issue #114.
             if 'entries' in result and len(result['entries']) > 0:
                 for entry in result['entries']:
                     if entry is None:

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -139,6 +139,34 @@ series:
         replace: 'Ep\\1'
 ```
 
+### "No video_url"
+
+The matcher couldn't return a usable URL for the episode. Two distinct
+causes — check the debug log to tell them apart:
+
+**1. No entry in the playlist matched the Sonarr episode title.** The
+debug log shows several `"<title>" title did not match pattern` lines
+and **no** `[youtube] Extracting URL: ...` between them. Verify:
+
+- The episode actually exists in the configured playlist/channel as a
+  publicly viewable video. Open the playlist in an incognito browser
+  window to confirm.
+- If the episode appears as `[Private video]` in the log (yt-dlp also
+  prints `INFO - N unavailable videos are hidden`), yt-dlp can't read
+  its title. Supply cookies from an account that can see it, or wait
+  until the creator makes it public.
+- Your `regex.sonarr` rewrite produces a substring of the YouTube
+  title (case-insensitive). Compare them side-by-side in a debug-mode
+  log to confirm.
+
+**2. A matching entry was found, fully extracted, but the URL field
+came back empty.** The debug log shows `[youtube] Extracting URL: ...`
+followed by webpage download, deno JS challenge, and m3u8 information
+— *then* `No video_url`. This was a bug in older releases affecting
+HLS YouTube videos (most modern uploads); fixed in the release that
+addresses issue #114. Pull a current image (`:latest` or `:dev`) and
+re-run.
+
 ### Format Selection Errors
 
 If getting "No suitable format" errors:


### PR DESCRIPTION
## Summary

The fix merged in #116 walked playlist entries correctly but read the wrong field — `entries[i].get('url')` returns `None` for matched YouTube entries when format selection requires audio+video merge (i.e., HLS, which is most modern uploads). Net effect: matchtitle worked, the matched entry was fully extracted (m3u8 manifest, deno JS challenge, everything), and then the python code threw the result away because the field it read was `None`.

This PR reads `webpage_url` first (always populated by the YouTube extractor at `extractor/youtube/_video.py:4179`) and falls back to `url` for non-YouTube extractors. Documents the gotcha at the call site and in CLAUDE.md so the next cleanup pass doesn't silently re-break it.

## Root cause walkthrough

For the issue reporter's playlist (`PLvbcAI8Z6179NsRNc9OrUcRMNOf7cYCZj`, Grand Prairie episode):

1. yt-dlp expands the playlist, applies `matchtitle="GRAND[\ ]*PRAIRIE"`, picks `j3Vfe5KH4f8` (confirmed via web search as "Day Trip to Grand Prairie: 🐎 BBQ, Horse Racing, Indoor Rock Climbing").
2. The matched entry is fully extracted — the dev log shows webpage download, android vr player API, deno JS challenge, m3u8 information download.
3. `process_video_result` runs format selection. Default selector `bv*+ba/b` picks separate video + audio HLS streams that need ffmpeg merge.
4. `YoutubeDL._merge` (`YoutubeDL.py:2456`) builds a "merged format" dict containing `requested_formats`, `format`, `format_id`, `ext`, etc. — but **no top-level `url`**.
5. `info_dict.update(best_format)` at `YoutubeDL.py:3118` merges those fields into the entry. `entry['url']` stays unset (the YouTube extractor never set it directly).
6. Our code calls `entry.get('url')` → `None` → logs `No video_url` → drops the match.

`webpage_url` is set directly by the YouTube extractor and is always present, so reading it instead resolves the case.

## Behavioral changes

| | Before (`.get('url')`) | After (`webpage_url or url`) |
|---|---|---|
| Modern HLS YouTube videos | Silently dropped | Downloads correctly |
| Old progressive-format videos | Direct stream URL → downloader pulls bytes | Watch URL → downloader re-extracts then pulls |
| Non-YouTube extractors that only set `url` | Works | Works (fallback) |
| User-configured `format:` / `subtitles:` | **Silently ignored** when input was a raw stream URL | Applied (downloader starts from webpage URL) |
| Stale auth tokens if download queue is slow | Possible 403 | Always fresh (re-extract immediately before download) |
| Extra time per download | — | +~5s per video (one extra extraction) |

The format/subtitle behavior is the most interesting: the previous "working" path passed a Googlevideo direct-stream URL to `ydl.download([dlurl])`, which silently ignores `format`, `merge_output_format`, and subtitle postprocessors because those only take effect when yt-dlp starts from a webpage URL. After this fix, users' configs actually do what they say.

## Files

- `app/stream_harvestarr.py` — change the field read, document why in a comment at the call site.
- `CLAUDE.md` — new "yt-dlp playlist matching gotchas" section covering both the missing-`url` quirk and the knock-on effect of re-extraction, with an explicit "don't simplify back" note.

## Test plan

- [ ] Pull `:dev` against an HLS YouTube playlist (e.g., the issue reporter's `PLvbcAI8Z6179NsRNc9OrUcRMNOf7cYCZj`) and confirm the matched episode actually downloads.
- [ ] Confirm an older progressive-format YouTube video still downloads.
- [ ] Spot-check a config with a custom `format:` (e.g., `bestvideo[height<=720]+bestaudio`) and confirm the resulting file matches the requested format (previously this would have been ignored).
- [ ] Confirm subtitle embedding still works for configs that have it enabled.
- [ ] CI multi-arch build + YouTube smoke test green.

Fixes #114 (for real this time).

---
_Generated by [Claude Code](https://claude.ai/code/session_013Evbiy5SYmCKH75xsGmfbx)_