### PR TITLE
Release: ytsearch webpage_url fix (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,39 @@ All work follows: **feature branch → `development` → `main`**.
   Treat it as required — if it goes red, fix the image rather than
   merging around it.
 
+## yt-dlp playlist matching gotchas
+
+`ytsearch()` in `app/stream_harvestarr.py` calls
+`yt_dlp.YoutubeDL.extract_info(playlist_url, download=False)` with
+`matchtitle` set to a regex built from the Sonarr episode name. Two
+non-obvious behaviors bit us in issue #114:
+
+1. **Matched entries don't always have a top-level `url` field.** The
+   YouTube extractor sets `info_dict['webpage_url']` directly (the
+   canonical `https://www.youtube.com/watch?v=ID` URL) but `url` is
+   only populated when format selection picks a *single* non-merge
+   format. HLS videos — the default for modern YouTube uploads —
+   trigger ffmpeg audio+video merge; the merged "format" dict built
+   in `YoutubeDL._merge` has `requested_formats` but no top-level
+   `url`. After `info_dict.update(best_format)`, `entry.get('url')`
+   returns None even though extraction succeeded (m3u8 manifest
+   downloaded, deno JS challenge solved, etc.). Always read
+   `entry.get('webpage_url') or entry.get('url')` — the fallback is
+   there for non-YouTube extractors that only populate `url`.
+
+2. **Reading webpage_url means the downstream `download()` call
+   re-extracts.** The previous "working" path passed a direct
+   Googlevideo stream URL to the second `ydl.download([dlurl])` call,
+   which silently ignored the configured `format`,
+   `merge_output_format`, and subtitle postprocessors (those options
+   only apply when yt-dlp starts from a webpage URL, not a raw stream
+   URL). Passing the watch URL costs an extra ~5s extraction per
+   download but makes the user's format/subtitle config actually work
+   and avoids stale auth-token 403s when downloads queue up.
+
+If you ever feel tempted to "simplify" back to `.get('url')`, don't —
+re-read #114 first.
+
 ## Adding new architectures
 
 If a new platform is added to `main.yaml` / `cron.yaml`, also add it to

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -426,10 +426,12 @@ class StreamHarvester(object):
         else:
             video_url = None
             if 'entries' in result and len(result['entries']) > 0:
-                try:
-                    video_url = result['entries'][0].get('url')
-                except Exception as e:
-                    logger.error(e)
+                for entry in result['entries']:
+                    if entry is None:
+                        continue
+                    video_url = entry.get('url')
+                    if video_url:
+                        break
             else:
                 video_url = result.get('url')
             if playlist == video_url:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -429,11 +429,11 @@ class StreamHarvester(object):
                 for entry in result['entries']:
                     if entry is None:
                         continue
-                    video_url = entry.get('url')
+                    video_url = entry.get('webpage_url') or entry.get('url')
                     if video_url:
                         break
             else:
-                video_url = result.get('url')
+                video_url = result.get('webpage_url') or result.get('url')
             if playlist == video_url:
                 return False, ''
             if video_url is None:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -425,6 +425,15 @@ class StreamHarvester(object):
             logger.error(e)
         else:
             video_url = None
+            # Prefer webpage_url over url: yt-dlp's YouTube extractor only sets
+            # url when format selection picks a single non-merge format. HLS
+            # videos (most modern YouTube uploads) trigger ffmpeg audio+video
+            # merge — the "merged format" dict (YoutubeDL._merge) has
+            # requested_formats but no top-level url, so info_dict.update gives
+            # us an entry with .get('url') == None even though extraction
+            # succeeded. webpage_url is always set by the YouTube extractor
+            # directly; the .get('url') fallback covers other extractors that
+            # only populate url. See issue #114.
             if 'entries' in result and len(result['entries']) > 0:
                 for entry in result['entries']:
                     if entry is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.33.1
+requests>=2.34.2
 yt-dlp>=2026.3.17
 yt-dlp-ejs>=0.8.0
 pyyaml>=6.0.3

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -139,6 +139,34 @@ series:
         replace: 'Ep\\1'
 ```
 
+### "No video_url"
+
+The matcher couldn't return a usable URL for the episode. Two distinct
+causes — check the debug log to tell them apart:
+
+**1. No entry in the playlist matched the Sonarr episode title.** The
+debug log shows several `"<title>" title did not match pattern` lines
+and **no** `[youtube] Extracting URL: ...` between them. Verify:
+
+- The episode actually exists in the configured playlist/channel as a
+  publicly viewable video. Open the playlist in an incognito browser
+  window to confirm.
+- If the episode appears as `[Private video]` in the log (yt-dlp also
+  prints `INFO - N unavailable videos are hidden`), yt-dlp can't read
+  its title. Supply cookies from an account that can see it, or wait
+  until the creator makes it public.
+- Your `regex.sonarr` rewrite produces a substring of the YouTube
+  title (case-insensitive). Compare them side-by-side in a debug-mode
+  log to confirm.
+
+**2. A matching entry was found, fully extracted, but the URL field
+came back empty.** The debug log shows `[youtube] Extracting URL: ...`
+followed by webpage download, deno JS challenge, and m3u8 information
+— *then* `No video_url`. This was a bug in older releases affecting
+HLS YouTube videos (most modern uploads); fixed in the release that
+addresses issue #114. Pull a current image (`:latest` or `:dev`) and
+re-run.
+
 ### Format Selection Errors
 
 If getting "No suitable format" errors:


### PR DESCRIPTION
Promotes the #114 fix (and supporting commits) from `development` to `main` after the reporter confirmed `:dev` resolves their issue.

## What ships

- `fix(ytsearch): read webpage_url from matched entry, not url` (#117) — the actual fix. yt-dlp doesn't populate the top-level `url` field on extracted YouTube entries when format selection requires audio+video merge (i.e., HLS, most modern uploads). Read `webpage_url` instead, fall back to `url` for non-YouTube extractors.
- `fix(ytsearch): pick first matching entry from yt-dlp playlist results` (#116) — first-pass fix that walked entries correctly but read the wrong field. Kept in history because it does close a separate edge case (`None` entries in the list).
- `docs(ytsearch)` — inline comment at the call site + new "yt-dlp playlist matching gotchas" section in CLAUDE.md so the next cleanup pass doesn't re-break this.
- `docs(wiki): troubleshooting entry for "No video_url"` — splits the two failure modes by log signature so users can self-diagnose.
- `chore(deps): bump requirements floors to PyPI latest` — routine.

## Test plan

- [x] Reporter confirmed `:dev` image fixes their playlist (#114).
- [x] CI green on #117 into `development` (build all arches, smoke test, CodeQL, Analyze python/actions).
- [ ] `:latest` Docker Builder workflow goes green on merge.

Closes #114 once merged and the release publishes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Evbiy5SYmCKH75xsGmfbx)_