### PR TITLE
fix(logging): drop explicit yt-dlp opts dumps to clear CodeQL

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -4,7 +4,7 @@ import yt_dlp
 import os
 import sys
 import re
-from utils import upperescape, checkconfig, offsethandler, safe_opts_summary, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
+from utils import upperescape, checkconfig, offsethandler, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
 from datetime import datetime
 import schedule
 import time
@@ -380,8 +380,6 @@ class StreamHarvester(object):
         return ytdlopts
 
     def ytsearch(self, ydl_opts, playlist):
-        if self.debug:
-            logger.debug('yt-dlp search opts: %s', safe_opts_summary(ydl_opts))
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 result = ydl.extract_info(
@@ -490,8 +488,6 @@ class StreamHarvester(object):
                                     'progress_hooks': [ytdl_hooks_debug],
                                 })
                                 logger.debug('yt-dlp opts configured for downloading')
-                            if self.debug:
-                                logger.debug('yt-dlp download opts: %s', safe_opts_summary(ytdl_format_options))
                             try:
                                 with yt_dlp.YoutubeDL(ytdl_format_options) as ydl:
                                      ydl.download([dlurl])

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -4,7 +4,7 @@ import yt_dlp
 import os
 import sys
 import re
-from utils import upperescape, checkconfig, offsethandler, redact_sensitive, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
+from utils import upperescape, checkconfig, offsethandler, safe_opts_summary, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
 from datetime import datetime
 import schedule
 import time
@@ -381,7 +381,7 @@ class StreamHarvester(object):
 
     def ytsearch(self, ydl_opts, playlist):
         if self.debug:
-            logger.debug('yt-dlp search opts: %s', redact_sensitive(ydl_opts))
+            logger.debug('yt-dlp search opts: %s', safe_opts_summary(ydl_opts))
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 result = ydl.extract_info(
@@ -491,7 +491,7 @@ class StreamHarvester(object):
                                 })
                                 logger.debug('yt-dlp opts configured for downloading')
                             if self.debug:
-                                logger.debug('yt-dlp download opts: %s', redact_sensitive(ytdl_format_options))
+                                logger.debug('yt-dlp download opts: %s', safe_opts_summary(ytdl_format_options))
                             try:
                                 with yt_dlp.YoutubeDL(ytdl_format_options) as ydl:
                                      ydl.download([dlurl])

--- a/app/utils.py
+++ b/app/utils.py
@@ -20,12 +20,38 @@ SENSITIVE_KEY_SUBSTRINGS = (
     'username',
 )
 
+# yt-dlp opts keys that are safe to dump verbatim in debug logs. Allowlist
+# by design: any key not listed (cookiefile, username, password, ...) is
+# dropped entirely so future sensitive options never accidentally leak.
+# This is what stream_harvestarr's own debug dumps use. yt-dlp's own log
+# messages still flow through YoutubeDLLogger + redact_sensitive separately.
+SAFE_OPTS_KEYS = frozenset({
+    'format', 'merge_output_format', 'outtmpl', 'quiet',
+    'noplaylist', 'forceipv4', 'sleep_interval', 'max_sleep_interval',
+    'nocontinue', 'nooverwrites', 'throttled_rate', 'concurrent_fragments',
+    'playlistreverse', 'ignoreerrors', 'matchtitle', 'match-filter',
+    'match_filter', 'writesubtitles', 'writeautomaticsub', 'subtitleslangs',
+    'postprocessors', 'js_runtimes', 'sleep_interval_requests',
+    'progress_hooks',
+})
+
 # Pre-compiled patterns for redacting secrets that appear inside strings
 # (URLs, JSON-ish blobs). Keep these narrow on purpose — any pattern
 # broad enough to chew on legitimate log content is worse than no
 # redaction at all, because users stop trusting the redacted output.
 _APIKEY_QUERY_RE = re.compile(r'(apikey=)[^&\s]+', re.IGNORECASE)
 _APIKEY_JSON_RE = re.compile(r'(api[_-]?key["\']?\s*:\s*["\']?)[^&\s,}"\']+', re.IGNORECASE)
+
+
+def safe_opts_summary(opts):
+    """Return a copy of a yt-dlp opts dict containing only allowlisted keys.
+
+    Used for debug-mode logging of opts. The allowlist is the safety
+    boundary: anything not on it (cookiefile path, username, password,
+    cookies-file path, future-added credentials) is dropped before the
+    dict ever reaches the logger.
+    """
+    return {k: opts[k] for k in opts if k in SAFE_OPTS_KEYS}
 
 
 def redact_sensitive(data):

--- a/app/utils.py
+++ b/app/utils.py
@@ -20,38 +20,12 @@ SENSITIVE_KEY_SUBSTRINGS = (
     'username',
 )
 
-# yt-dlp opts keys that are safe to dump verbatim in debug logs. Allowlist
-# by design: any key not listed (cookiefile, username, password, ...) is
-# dropped entirely so future sensitive options never accidentally leak.
-# This is what stream_harvestarr's own debug dumps use. yt-dlp's own log
-# messages still flow through YoutubeDLLogger + redact_sensitive separately.
-SAFE_OPTS_KEYS = frozenset({
-    'format', 'merge_output_format', 'outtmpl', 'quiet',
-    'noplaylist', 'forceipv4', 'sleep_interval', 'max_sleep_interval',
-    'nocontinue', 'nooverwrites', 'throttled_rate', 'concurrent_fragments',
-    'playlistreverse', 'ignoreerrors', 'matchtitle', 'match-filter',
-    'match_filter', 'writesubtitles', 'writeautomaticsub', 'subtitleslangs',
-    'postprocessors', 'js_runtimes', 'sleep_interval_requests',
-    'progress_hooks',
-})
-
 # Pre-compiled patterns for redacting secrets that appear inside strings
 # (URLs, JSON-ish blobs). Keep these narrow on purpose — any pattern
 # broad enough to chew on legitimate log content is worse than no
 # redaction at all, because users stop trusting the redacted output.
 _APIKEY_QUERY_RE = re.compile(r'(apikey=)[^&\s]+', re.IGNORECASE)
 _APIKEY_JSON_RE = re.compile(r'(api[_-]?key["\']?\s*:\s*["\']?)[^&\s,}"\']+', re.IGNORECASE)
-
-
-def safe_opts_summary(opts):
-    """Return a copy of a yt-dlp opts dict containing only allowlisted keys.
-
-    Used for debug-mode logging of opts. The allowlist is the safety
-    boundary: anything not on it (cookiefile path, username, password,
-    cookies-file path, future-added credentials) is dropped before the
-    dict ever reaches the logger.
-    """
-    return {k: opts[k] for k in opts if k in SAFE_OPTS_KEYS}
 
 
 def redact_sensitive(data):


### PR DESCRIPTION
## Summary

Follow-up to #127. CodeQL's `py/clear-text-logging-sensitive-data` flagged the two `logger.debug('yt-dlp ... opts: %s', ...)` calls added in #127. First commit on this PR tried an allowlist helper (`safe_opts_summary`); CodeQL flagged it again because it traces taint through any function call that isn't an explicitly modeled sanitizer. Second commit drops the explicit dumps entirely.

## What this preserves (the actual #127 win)

- `YoutubeDLLogger.{info,debug,warning,error}` still wrap **yt-dlp's own output** through `redact_sensitive`. That covers the real leak path: yt-dlp's verbose mode logs URLs and serialized opts, and we sanitize them on the way through.
- `redact_sensitive`'s URL apikey scrubbing still runs on every string yt-dlp emits.
- When #120 lands and adds `username`/`password` to opts, those values never reach a logger from our code, and yt-dlp's own output is sanitized en route.

## What this drops

- The two `logger.debug('yt-dlp ... opts: %s', ...)` lines at `ytsearch` entry and inside `download`.
- `safe_opts_summary()` and `SAFE_OPTS_KEYS` — dead code without the call sites.

## Why give up on the dump rather than add a CodeQL sanitizer model

A model pack for `safe_opts_summary` would silence the analyzer but adds maintenance debt (a `.github/codeql/` config to keep in sync with the function) for a feature whose only benefit is dumping a dict that the user already authored in `config.yml`. The cost/benefit doesn't justify it.

## Test plan

- [x] Syntax check on both files.
- [x] No dangling references to `safe_opts_summary` / `SAFE_OPTS_KEYS` anywhere.
- [x] `redact_sensitive` and `YoutubeDLLogger` wiring still in place.
- [ ] CodeQL re-scan shows previously-flagged lines no longer exist.

https://claude.ai/code/session_01AUpT8PSFhNkdyDT74nFxp8