### PR TITLE
chore(claude): wire up PR-review guardrails and label taxonomy

### DIFF
--- a/.github/workflows/labels-bootstrap.yaml
+++ b/.github/workflows/labels-bootstrap.yaml
@@ -1,0 +1,68 @@
+name: Labels Bootstrap
+
+# Idempotent one-shot to create / refresh the namespaced label taxonomy
+# documented in CLAUDE.md ("Label conventions"). Trigger from the Actions
+# UI when labels drift, get deleted, or when adding new entries below.
+# Re-running is harmless; --force overwrites color/description but
+# preserves all existing label applications on issues and PRs.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create / refresh labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          labels=(
+            # intent: decision state on feat(...) PRs (stage-1 of review workflow)
+            "intent: needs-decision|D4C5F9|Feature PR awaiting maintainer in-scope decision"
+            "intent: approved|0E8A16|Maintainer confirmed in-scope; ready for technical review"
+            "intent: declined|5C5C5C|Maintainer declined; closed or open for discussion only"
+            "intent: deferred|BFD4F2|In-scope but parked for later"
+
+            # type: change category (from conventional-commit prefix)
+            "type: feat|A2EEEF|New feature or capability"
+            "type: fix|D73A4A|Bug fix"
+            "type: chore|FEF2C0|Maintenance / cleanup; no user-facing change"
+            "type: docs|0075CA|Documentation only"
+            "type: refactor|BFD4F2|Internal restructuring; no behavior change"
+            "type: deps|0366D6|Dependency version bump"
+            "type: ci|006B75|CI / GitHub Actions workflow change"
+
+            # area: which part of the codebase
+            "area: docker|5319E7|Dockerfile, image layers, runtime install"
+            "area: extractor|E99695|yt-dlp invocation, format selection, playlist matching"
+            "area: scheduler|F9D0C4|Schedule polling, cron scheduling"
+            "area: sonarr|35C5F0|Sonarr API integration"
+            "area: config|FBCA04|config.yaml parsing, env var handling"
+            "area: workflows|1D76DB|GitHub Actions workflow files"
+            "area: docs|7057FF|README, wiki, CLAUDE.md, code comments"
+            "area: unraid|F1502F|Unraid community template"
+
+            # status: ephemeral PR-state markers
+            "status: needs-tests|FBCA04|Touches behavior but lacks coverage"
+            "status: breaking-change|B60205|User-visible breaking change"
+            "status: needs-rebase|E99695|Has merge conflicts; author needs to update"
+          )
+
+          for entry in "${labels[@]}"; do
+            IFS='|' read -r name color desc <<< "$entry"
+            echo "::group::${name}"
+            gh label create "$name" \
+              --color "$color" \
+              --description "$desc" \
+              --force \
+              --repo "$GITHUB_REPOSITORY"
+            echo "::endgroup::"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,49 @@ If you're picking up a session mid-flight (handoff context, resumed
 work), don't assume a prior session's "yes" carries over — ask again.
 Session-bounded intent is the safer default.
 
+## Label conventions
+
+Four namespaces, applied by Claude on every PR Claude opens or reviews.
+The namespaces answer different questions, so multiple may apply to
+one PR. Existing flat labels (`bug`, `enhancement`, `dependencies`,
+etc.) are kept for historical consistency but not applied on new work.
+
+- `intent:` — decision state on `feat(...)` PRs. Values:
+  `needs-decision`, `approved`, `declined`, `deferred`. Open a
+  `feat(...)` PR with `intent: needs-decision`; the user's stage-1
+  answer replaces it. Non-`feat` PRs skip this namespace.
+- `type:` — change category from the conventional-commit prefix.
+  Values: `feat`, `fix`, `chore`, `docs`, `refactor`, `deps`, `ci`.
+  Exactly one per PR.
+- `area:` — codebase region. Values: `docker`, `extractor`,
+  `scheduler`, `sonarr`, `config`, `workflows`, `docs`, `unraid`.
+  Multiple allowed when a PR genuinely spans regions.
+- `status:` — ephemeral PR-state. Values: `needs-tests`,
+  `breaking-change`, `needs-rebase`. Add when the condition holds;
+  remove when resolved. Not all PRs carry a `status:` label.
+
+### Legacy labels — handle, don't apply
+
+- `bug` / `enhancement` — superseded by `type: fix` / `type: feat`.
+  Don't add to new PRs; leave alone where already applied.
+- `dependencies` — Dependabot applies this automatically. Don't strip
+  it. Claude does not also add `type: deps` on Dependabot PRs — the
+  auto-label is operative.
+- `Stale` — managed by `stale.yaml`. Never rename (the workflow
+  references it by exact name).
+- `awaiting-approval`, `wip` — exempt-from-stale markers per
+  `stale.yaml`. Apply when a PR/issue is intentionally paused.
+- `good first issue`, `question`, `python` — keep as-is. Community
+  signaling and Dependabot's ecosystem tag.
+
+### Provisioning
+
+Labels are created by `.github/workflows/labels-bootstrap.yaml`
+(`workflow_dispatch` only). Trigger from the Actions UI when adding
+new namespace values, or if a label gets deleted. The workflow is
+idempotent: `gh label create --force` updates color/description on
+existing labels without dropping any historical applications.
+
 ## Merging
 
 - **Never merge into `main`.** No exceptions. If a PR targets `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,51 @@ All work follows: **feature branch → `development` → `main`**.
 - Keep `development` in sync with `main` after every release so the next
   feature branch starts from a clean base.
 
+## PR review workflow (guardrails)
+
+Two-stage check before any `APPROVE` lands on a PR — applies to both
+contributor PRs and Claude-authored PRs.
+
+**Stage 1 — project-intent check (features only).** For any `feat(...)`
+PR, before doing the technical review, ask the user via
+`AskUserQuestion` whether this is a feature the project wants. Wait
+for an explicit "yes" recorded in the session before doing the deep
+review or submitting `APPROVE`. If the user says "no" / "not now",
+post a `COMMENT` review explaining the position and leave the PR
+open without an approve. Do not silently sit on it.
+
+`fix(...)`, `chore(...)`, `docs(...)`, `refactor(...)` PRs skip
+stage 1 — bug fixes are inherently in-scope, cleanups don't expand
+surface area. Go straight to stage 2 at Claude's discretion.
+
+**Stage 2 — technical review.** Submit `REQUEST_CHANGES` for any
+blocking issue. Submit `APPROVE` only when **both** are true:
+
+1. Technical review is clean (no blockers, CI green).
+2. For `feat(...)`: the user gave an explicit documented "yes" in
+   this session for this PR.
+
+If you're picking up a session mid-flight (handoff context, resumed
+work), don't assume a prior session's "yes" carries over — ask again.
+Session-bounded intent is the safer default.
+
+## Merging
+
+- **Never merge into `main`.** No exceptions. If a PR targets `main`
+  directly, immediately submit `REQUEST_CHANGES` asking for it to be
+  retargeted to `development`. GitHub branch protection on `main` is
+  the defense-in-depth (the maintainer sets that up server-side); the
+  rule here is the in-Claude tripwire.
+- **Promoting `development → main` is a maintainer-only action.**
+  Claude does not open the promotion PR and does not merge it. If the
+  user explicitly asks Claude to *prepare* the diff for the
+  promotion, that's fine — but the PR-create and merge buttons are
+  human-only.
+- For PRs targeting `development`: after `APPROVE` is submitted and
+  CI is green, Claude may merge (regular merge, matching the
+  repository's history). For `feat(...)` PRs, the stage-1 documented
+  "yes" must already be on record before the merge.
+
 ## Container build expectations
 
 - The image is `python:3.14-alpine` based.


### PR DESCRIPTION
## Summary

Two-commit PR landing the operational policy layer for PR review:

- `fed731f docs(claude)` — adds the two-stage PR review workflow (stage-1 intent check on `feat(...)`, stage-2 technical) and the "never merge into main" tripwire to CLAUDE.md
- `28f04c8 chore(labels)` — adds a four-namespace label system (`intent:` / `type:` / `area:` / `status:`) plus a `workflow_dispatch` bootstrap action that provisions them idempotently

The label taxonomy is referenced by the review workflow (the stage-1 ask flips `intent: needs-decision` → `intent: approved | declined | deferred`), so the two changes ship together.

### Existing labels are kept

`bug`, `enhancement`, `dependencies`, `Stale`, `awaiting-approval`, `wip`, `good first issue`, `question`, `python` are all left in place. The bootstrap workflow only creates net-new labels — no historical applications are touched, Dependabot keeps applying `dependencies` automatically, and `stale.yaml` continues to reference `Stale` / `awaiting-approval` / `wip` by their existing names.

### Activating the labels

`workflow_dispatch` workflows only surface in the Actions UI from the default branch, so the bootstrap action becomes runnable after this hits `development` and then `main`. One trigger creates all 22 namespaced labels; the workflow is `--force` and idempotent if re-run later.

## Test plan

- [ ] CI is green on this PR (build-multiarch + YouTube smoke test)
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/labels-bootstrap.yaml'))"` passes (already verified locally)
- [ ] Visual review of CLAUDE.md "Label conventions" section for tone/clarity
- [ ] After the dev→main promotion, trigger "Labels Bootstrap" once from the Actions UI and confirm 22 labels appear in Issues → Labels

https://claude.ai/code/session_01Ybwz9PdsbJJ3pTXuM43xWo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ybwz9PdsbJJ3pTXuM43xWo)_