### PR TITLE
feat(yaml): add yaml language server

### DIFF
--- a/app/config-schema.json
+++ b/app/config-schema.json
@@ -135,46 +135,45 @@
         }
       }
     },
-    "series": {
+    "services": {
       "type": "array",
-      "description": "List of series to monitor and download.",
+      "description": "Optional list of named service definitions. A service holds shared configuration (credentials, cookies, subtitles, offset, etc.) that series can inherit by referencing the service's title. Any key set at the series level overrides the same key from the service.",
       "minItems": 1,
       "items": {
-        "$ref": "#/definitions/series_entry"
+        "$ref": "#/definitions/service_entry"
+      }
+    },
+    "series": {
+      "type": "array",
+      "description": "List of series to monitor and download. Each entry is either standalone (full URL, no service key) or service-linked (service name + relative URL path).",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/series_standalone" },
+          { "$ref": "#/definitions/series_linked" }
+        ]
       }
     }
   },
   "definitions": {
-    "series_entry": {
+
+    "service_entry": {
       "type": "object",
-      "description": "A single series to monitor.",
+      "description": "A named service definition providing shared configuration for series that reference it.",
       "required": ["title", "url"],
       "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string",
-          "description": "Series name. Must match the series title in Sonarr exactly.",
+          "description": "Unique name for this service. Series reference it via the 'service' key.",
           "minLength": 1,
-          "examples": ["Smarter Every Day", "The Slow Mo Guys"]
+          "examples": ["YouTube Members", "Patreon"]
         },
         "url": {
           "type": "string",
-          "description": "YouTube channel or playlist URL to monitor.",
+          "description": "Base URL for the service. Series using this service provide a relative path that is joined onto this URL.",
           "format": "uri",
-          "examples": [
-            "https://www.youtube.com/channel/UC6107grRI4m0o2-emgoDnAA",
-            "https://www.youtube.com/playlist?list=PLxxxxxxxx"
-          ]
-        },
-        "format": {
-          "type": "string",
-          "description": "Override the global default_format for this series. See https://github.com/yt-dlp/yt-dlp#format-selection.",
-          "minLength": 1,
-          "examples": [
-            "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
-            "bestvideo[height<=720]+bestaudio/best[height<=720]",
-            "bestvideo[height<=2160]+bestaudio/best"
-          ]
+          "examples": ["https://www.youtube.com/", "https://www.patreon.com/"]
         },
         "cookies_file": {
           "type": "string",
@@ -192,9 +191,18 @@
           "description": "Password for sites requiring authentication. Must be used together with 'username'. Ensure config.yml is chmod 600.",
           "minLength": 1
         },
+        "format": {
+          "type": "string",
+          "description": "Default YT-DLP format string for all series on this service. Can be overridden per-series.",
+          "minLength": 1,
+          "examples": [
+            "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+            "bestvideo[height<=1080]+bestaudio/best[height<=1080]"
+          ]
+        },
         "playlistreverse": {
           "type": "boolean",
-          "description": "Process playlist in reverse order (oldest first). Set to False to process newest-first.",
+          "description": "Default playlist processing order for series on this service. Can be overridden per-series.",
           "default": true
         },
         "offset": {
@@ -212,6 +220,132 @@
         "password": ["username"]
       }
     },
+
+    "series_shared_overridable": {
+      "description": "Overridable fields that can be set at service level and overridden at series level.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Series name. Must match the series title in Sonarr exactly.",
+          "minLength": 1,
+          "examples": ["Smarter Every Day", "The Slow Mo Guys"]
+        },
+        "format": {
+          "type": "string",
+          "description": "Override the format for this series. Falls back to the service format, then to ytdl.default_format.",
+          "minLength": 1,
+          "examples": [
+            "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+            "bestvideo[height<=720]+bestaudio/best[height<=720]",
+            "bestvideo[height<=2160]+bestaudio/best"
+          ]
+        },
+        "cookies_file": {
+          "type": "string",
+          "description": "Override the cookie file for this series. Falls back to the service cookies_file.",
+          "minLength": 1,
+          "examples": ["youtube_cookies.txt"]
+        },
+        "username": {
+          "type": "string",
+          "description": "Override the username for this series. Must be used together with 'password'.",
+          "minLength": 1
+        },
+        "password": {
+          "type": "string",
+          "description": "Override the password for this series. Must be used together with 'username'.",
+          "minLength": 1
+        },
+        "playlistreverse": {
+          "type": "boolean",
+          "description": "Override the playlist processing order for this series.",
+          "default": true
+        },
+        "offset": {
+          "$ref": "#/definitions/offset"
+        },
+        "subtitles": {
+          "$ref": "#/definitions/subtitles"
+        },
+        "regex": {
+          "$ref": "#/definitions/regex"
+        }
+      }
+    },
+
+    "series_standalone": {
+      "type": "object",
+      "description": "A standalone series with a full absolute URL. Does not inherit from any service.",
+      "required": ["title", "url"],
+      "additionalProperties": false,
+      "allOf": [{ "$ref": "#/definitions/series_shared_overridable" }],
+      "properties": {
+        "title": {},
+        "url": {
+          "type": "string",
+          "description": "Full absolute URL of the YouTube channel or playlist to monitor.",
+          "format": "uri",
+          "examples": [
+            "https://www.youtube.com/channel/UC6107grRI4m0o2-emgoDnAA",
+            "https://www.youtube.com/playlist?list=PLxxxxxxxx"
+          ]
+        },
+        "format": {},
+        "cookies_file": {},
+        "username": {},
+        "password": {},
+        "playlistreverse": {},
+        "offset": {},
+        "subtitles": {},
+        "regex": {}
+      },
+      "not": {
+        "required": ["service"]
+      },
+      "dependencies": {
+        "username": ["password"],
+        "password": ["username"]
+      }
+    },
+
+    "series_linked": {
+      "type": "object",
+      "description": "A series that inherits shared configuration from a named service. The 'url' is a relative path joined onto the service's base URL. Any key set here overrides the same key from the service.",
+      "required": ["title", "service", "url"],
+      "additionalProperties": false,
+      "allOf": [{ "$ref": "#/definitions/series_shared_overridable" }],
+      "properties": {
+        "title": {},
+        "service": {
+          "type": "string",
+          "description": "Name of the service to inherit configuration from. Must match the 'title' of an entry in the top-level 'services' list.",
+          "minLength": 1,
+          "examples": ["YouTube Members", "Patreon"]
+        },
+        "url": {
+          "type": "string",
+          "description": "Relative URL path appended to the service's base URL to form the full channel or playlist URL (e.g. 'channel/UCxxxxxxxx' or 'playlist?list=PLxxxxxxxx').",
+          "minLength": 1,
+          "examples": [
+            "channel/UC6107grRI4m0o2-emgoDnAA",
+            "playlist?list=PLxxxxxxxx"
+          ]
+        },
+        "format": {},
+        "cookies_file": {},
+        "username": {},
+        "password": {},
+        "playlistreverse": {},
+        "offset": {},
+        "subtitles": {},
+        "regex": {}
+      },
+      "dependencies": {
+        "username": ["password"],
+        "password": ["username"]
+      }
+    },
+
     "offset": {
       "type": "object",
       "description": "Delay downloading an episode until this amount of time has passed after the air date. Useful for member early-access or embargoed content. All fields are optional and additive.",
@@ -244,9 +378,10 @@
         }
       }
     },
+
     "subtitles": {
       "type": "object",
-      "description": "Subtitle download settings for this series.",
+      "description": "Subtitle download settings.",
       "additionalProperties": false,
       "properties": {
         "languages": {
@@ -271,6 +406,7 @@
         }
       }
     },
+
     "regex": {
       "type": "object",
       "description": "Regular expression patterns to transform episode titles before matching. Useful when YouTube and TVDB use different naming conventions.",
@@ -287,6 +423,7 @@
         }
       }
     },
+
     "regex_rule": {
       "type": "object",
       "description": "A single find-and-replace regex rule.",
@@ -311,5 +448,6 @@
         }
       }
     }
+
   }
 }

--- a/app/config-schema.json
+++ b/app/config-schema.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Stream Harvestarr Configuration",
+  "description": "Schema for Stream Harvestarr config.yml",
+  "type": "object",
+  "required": ["streamharvestarr", "sonarr", "ytdl", "series"],
+  "additionalProperties": false,
+  "properties": {
+    "streamharvestarr": {
+      "type": "object",
+      "description": "Core Stream Harvestarr application settings.",
+      "required": ["scan_interval", "debug"],
+      "additionalProperties": false,
+      "properties": {
+        "scan_interval": {
+          "type": "integer",
+          "description": "Minutes between each scan for new episodes.",
+          "minimum": 1,
+          "default": 1,
+          "examples": [1, 5, 60]
+        },
+        "debug": {
+          "type": "boolean",
+          "description": "Enable verbose logging output.",
+          "default": false
+        },
+        "download_delay": {
+          "type": "integer",
+          "description": "Seconds to wait between downloads. Recommended: 5-10 for rate limit prevention.",
+          "minimum": 0,
+          "default": 0,
+          "examples": [0, 5, 10]
+        },
+        "sleep_requests": {
+          "type": "integer",
+          "description": "Seconds to wait between API requests to streaming sites. Recommended: 1-3 for rate limit prevention.",
+          "minimum": 0,
+          "default": 0,
+          "examples": [0, 1, 3]
+        },
+        "rate_limit_sleep": {
+          "type": "integer",
+          "description": "Initial wait time in seconds when rate limited. Default is 900 (15 minutes). YouTube suggests up to 1 hour.",
+          "minimum": 0,
+          "default": 900,
+          "examples": [900, 1800, 3600]
+        },
+        "exponential_backoff": {
+          "type": "boolean",
+          "description": "Enable exponential backoff when repeatedly rate limited.",
+          "default": true
+        },
+        "backoff_multiplier": {
+          "type": "number",
+          "description": "Multiply wait time by this factor on each subsequent rate limit.",
+          "exclusiveMinimum": 0,
+          "default": 2.0,
+          "examples": [1.5, 2.0, 3.0]
+        },
+        "backoff_max": {
+          "type": "integer",
+          "description": "Maximum backoff time in seconds.",
+          "minimum": 1,
+          "default": 3600,
+          "examples": [1800, 3600, 7200]
+        }
+      }
+    },
+    "sonarr": {
+      "type": "object",
+      "description": "Connection settings for the Sonarr instance.",
+      "required": ["host", "port", "apikey", "ssl"],
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Sonarr server IP address or hostname.",
+          "examples": ["192.168.1.123", "sonarr.local", "localhost"]
+        },
+        "port": {
+          "type": "integer",
+          "description": "Sonarr port number. Default Sonarr port is 8989.",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8989,
+          "examples": [8989]
+        },
+        "apikey": {
+          "type": "string",
+          "description": "Sonarr API key, found in Sonarr under Settings → General → Security.",
+          "minLength": 1,
+          "examples": ["1234567890abcdef1234567890abcdef"]
+        },
+        "ssl": {
+          "type": "boolean",
+          "description": "Use HTTPS instead of HTTP when connecting to Sonarr.",
+          "default": false
+        },
+        "basedir": {
+          "type": "string",
+          "description": "Base URL path if Sonarr runs behind a reverse proxy (e.g. '/sonarr').",
+          "pattern": "^/",
+          "examples": ["/sonarr"]
+        },
+        "version": {
+          "type": "string",
+          "description": "Set to 'v4' if running Sonarr v4 beta to enable v3 API endpoint compatibility.",
+          "enum": ["v3", "v4"],
+          "examples": ["v4"]
+        }
+      }
+    },
+    "ytdl": {
+      "type": "object",
+      "description": "Global YT-DLP download settings applied to all series unless overridden.",
+      "required": ["default_format", "merge_output_format"],
+      "additionalProperties": false,
+      "properties": {
+        "default_format": {
+          "type": "string",
+          "description": "Default YT-DLP format selector string. See https://github.com/yt-dlp/yt-dlp#format-selection for syntax.",
+          "minLength": 1,
+          "examples": [
+            "bestvideo[width<=1920]+bestaudio/best[width<=1920]",
+            "bestvideo[height<=1080]+bestaudio/best[height<=1080]",
+            "bestvideo+bestaudio/best",
+            "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+          ]
+        },
+        "merge_output_format": {
+          "type": "string",
+          "description": "Output container format when merging video and audio streams.",
+          "enum": ["avi", "flv", "mkv", "mov", "mp4", "webm"],
+          "default": "mkv"
+        }
+      }
+    },
+    "series": {
+      "type": "array",
+      "description": "List of series to monitor and download.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/series_entry"
+      }
+    }
+  },
+  "definitions": {
+    "series_entry": {
+      "type": "object",
+      "description": "A single series to monitor.",
+      "required": ["title", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Series name. Must match the series title in Sonarr exactly.",
+          "minLength": 1,
+          "examples": ["Smarter Every Day", "The Slow Mo Guys"]
+        },
+        "url": {
+          "type": "string",
+          "description": "YouTube channel or playlist URL to monitor.",
+          "format": "uri",
+          "examples": [
+            "https://www.youtube.com/channel/UC6107grRI4m0o2-emgoDnAA",
+            "https://www.youtube.com/playlist?list=PLxxxxxxxx"
+          ]
+        },
+        "format": {
+          "type": "string",
+          "description": "Override the global default_format for this series. See https://github.com/yt-dlp/yt-dlp#format-selection.",
+          "minLength": 1,
+          "examples": [
+            "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+            "bestvideo[height<=720]+bestaudio/best[height<=720]",
+            "bestvideo[height<=2160]+bestaudio/best"
+          ]
+        },
+        "cookies_file": {
+          "type": "string",
+          "description": "Filename of the Netscape-format cookie file for authenticated content. Must be located in the config directory. Ensure the file has chmod 600 permissions.",
+          "minLength": 1,
+          "examples": ["youtube_cookies.txt"]
+        },
+        "username": {
+          "type": "string",
+          "description": "Username for sites requiring authentication. Must be used together with 'password'.",
+          "minLength": 1
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for sites requiring authentication. Must be used together with 'username'. Ensure config.yml is chmod 600.",
+          "minLength": 1
+        },
+        "playlistreverse": {
+          "type": "boolean",
+          "description": "Process playlist in reverse order (oldest first). Set to False to process newest-first.",
+          "default": true
+        },
+        "offset": {
+          "$ref": "#/definitions/offset"
+        },
+        "subtitles": {
+          "$ref": "#/definitions/subtitles"
+        },
+        "regex": {
+          "$ref": "#/definitions/regex"
+        }
+      },
+      "dependencies": {
+        "username": ["password"],
+        "password": ["username"]
+      }
+    },
+    "offset": {
+      "type": "object",
+      "description": "Delay downloading an episode until this amount of time has passed after the air date. Useful for member early-access or embargoed content. All fields are optional and additive.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "weeks": {
+          "type": "integer",
+          "description": "Number of weeks to wait after the air date.",
+          "minimum": 0,
+          "examples": [1, 2]
+        },
+        "days": {
+          "type": "integer",
+          "description": "Number of days to wait after the air date.",
+          "minimum": 0,
+          "examples": [2, 3, 7]
+        },
+        "hours": {
+          "type": "integer",
+          "description": "Number of hours to wait after the air date.",
+          "minimum": 0,
+          "examples": [3, 6, 12]
+        },
+        "minutes": {
+          "type": "integer",
+          "description": "Number of minutes to wait after the air date.",
+          "minimum": 0,
+          "examples": [30, 60]
+        }
+      }
+    },
+    "subtitles": {
+      "type": "object",
+      "description": "Subtitle download settings for this series.",
+      "additionalProperties": false,
+      "properties": {
+        "languages": {
+          "type": "array",
+          "description": "List of ISO 639-1 language codes for subtitles to download.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "description": "ISO 639-1 two-letter language code.",
+            "minLength": 2,
+            "maxLength": 5,
+            "examples": ["en", "es", "fr", "de", "it", "pt", "ja", "ko", "zh", "ru", "ar"]
+          },
+          "default": ["en"],
+          "examples": [["en"], ["en", "es"], ["en", "es", "fr", "de"]]
+        },
+        "autogenerated": {
+          "type": "boolean",
+          "description": "Include auto-generated subtitles (e.g. YouTube auto-captions) in addition to manual subtitles.",
+          "default": false
+        }
+      }
+    },
+    "regex": {
+      "type": "object",
+      "description": "Regular expression patterns to transform episode titles before matching. Useful when YouTube and TVDB use different naming conventions.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "sonarr": {
+          "$ref": "#/definitions/regex_rule",
+          "description": "Transform the title as it appears in Sonarr before matching."
+        },
+        "site": {
+          "$ref": "#/definitions/regex_rule",
+          "description": "Transform the title as retrieved from the streaming site before matching."
+        }
+      }
+    },
+    "regex_rule": {
+      "type": "object",
+      "description": "A single find-and-replace regex rule.",
+      "required": ["match", "replace"],
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "string",
+          "description": "Python-flavour regular expression pattern to find in the title.",
+          "minLength": 1,
+          "examples": [
+            ".-.#[0-9]*$",
+            "^Ep([0-9]+)",
+            "^S[0-9]+E",
+            "\\s*\\([^)]+\\)$"
+          ]
+        },
+        "replace": {
+          "type": "string",
+          "description": "Replacement string. Use \\1, \\2, etc. for capture group back-references.",
+          "examples": ["", "Episode \\1", "E", ": \\1"]
+        }
+      }
+    }
+  }
+}

--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -1,3 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ryakel/stream-harvestarr/main/app/config-schema.json
+## Do not remove the above line
+## This file is a template remove the .template to use the file
+
 streamharvestarr:
     scan_interval: 1  # minutes between scans
     debug: False  # Set to True for a more verbose output
@@ -11,7 +15,7 @@ streamharvestarr:
 sonarr:
     host: 192.168.1.123
     port: 8989  # sonarr default port
-    apikey: 12341234
+    apikey: "12341234"
     ssl: false
     # basedir: '/sonarr'  # if you have sonarr running with a basedir set (e.g. behind a proxy)
     # version: v4 # if running v4 beta, allows the v3 api endpoints

--- a/app/utils.py
+++ b/app/utils.py
@@ -27,6 +27,61 @@ SENSITIVE_KEY_SUBSTRINGS = (
 _APIKEY_QUERY_RE = re.compile(r'(apikey=)[^&\s]+', re.IGNORECASE)
 _APIKEY_JSON_RE = re.compile(r'(api[_-]?key["\']?\s*:\s*["\']?)[^&\s,}"\']+', re.IGNORECASE)
 
+# yaml-language-server modeline written to the top of config file so
+# editors (VS Code, IntelliJ, etc.) automatically validate it against the
+# published schema without any per-workspace configuration.
+_SCHEMA_MODELINE = (
+    "# yaml-language-server: $schema=https://raw.githubusercontent.com/"
+    "ryakel/stream-harvestarr/main/app/config-schema.json"
+)
+_SCHEMA_GUARD = "## Do not remove the above line"
+_SCHEMA_HEADER = "{}\n{}\n".format(_SCHEMA_MODELINE, _SCHEMA_GUARD)
+
+
+def _has_schema_modeline(content: str) -> bool:
+    """Return True if *content* already contains a yaml-language-server modeline."""
+    return bool(re.search(r'#\s*yaml-language-server\s*:', content))
+
+
+def ensure_schema_modeline(path: str, logger=None) -> bool:
+    """Prepend the yaml-language-server schema modeline to a config file if absent.
+
+    If any ``yaml-language-server`` comment is
+    already present (including a user-supplied local ``$schema`` path) the
+    file is left untouched so local overrides are respected.
+
+    Args:
+        path:   Absolute path to the ``config.yml`` (or template) file.
+        logger: Optional logger instance for info/warning messages.
+
+    Returns:
+        ``True`` if the file was modified, ``False`` if it was already up-to-date
+        or if an I/O error prevented modification.
+    """
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            content = fh.read()
+    except OSError as exc:
+        if logger:
+            logger.warning('Could not read {} to check schema modeline: {}'.format(path, exc))
+        return False
+
+    if _has_schema_modeline(content):
+        return False  # already present — nothing to do
+
+    try:
+        with open(path, 'w', encoding='utf-8') as fh:
+            fh.write(_SCHEMA_HEADER + content)
+        if logger:
+            logger.info('Added yaml-language-server schema modeline to {}'.format(path))
+        return True
+    except OSError as exc:
+        if logger:
+            logger.warning(
+                'Could not write schema modeline to {} (check file permissions): {}'.format(path, exc)
+            )
+        return False
+
 
 def redact_sensitive(data):
     """Recursively redact secrets from data so it is safe to log.
@@ -60,10 +115,10 @@ def _normalize_quotes(string):
     two paths can't drift on which curly variants they recognize.
     """
     return (string
-        .replace('’', "'")  # right single quotation mark
-        .replace('‘', "'")  # left single quotation mark
-        .replace('“', '"')  # left double quotation mark
-        .replace('”', '"')  # right double quotation mark
+        .replace('\u2019', "'")  # right single quotation mark
+        .replace('\u2018', "'")  # left single quotation mark
+        .replace('\u201c', '"')  # left double quotation mark
+        .replace('\u201d', '"')  # right double quotation mark
     )
 
 
@@ -111,30 +166,39 @@ def upperescape(string):
 
 
 def checkconfig():
-    """Checks if config files exist in config path
-    If no config available, will copy template to config folder and exit script
+    """Checks if config files exist in config path.
 
-    returns:
+    If no config.yml is present, copies the template into place and exits so
+    the user can fill it in. If a config.yml *is* present, ensures it carries
+    a ``yaml-language-server`` modeline at the top so editors validate it
+    against the published schema automatically.
 
-        `cfg`: dict containing configuration values
+    Returns:
+        ``cfg``: dict containing configuration values
     """
     logger = logging.getLogger('stream_harvestarr')
     config_template = os.path.abspath(CONFIGFILE + '.template')
     config_template_exists = os.path.exists(os.path.abspath(config_template))
     config_file = os.path.abspath(CONFIGFILE)
     config_file_exists = os.path.exists(os.path.abspath(config_file))
+
     if not config_file_exists:
-        logger.critical('Configuration file not found.')  # print('Configuration file not found.')
+        logger.critical('Configuration file not found.')
         if not config_template_exists:
             os.system('cp /app/config.yml.template ' + config_template)
-        logger.critical("Create a config.yml using config.yml.template as an example.")  # sys.exit("Create a config.yml using config.yml.template as an example.")
+            # Ensure the template itself carries the modeline so users see it
+            # immediately when they open it to create their config.yml.
+            ensure_schema_modeline(config_template, logger)
+        logger.critical("Create a config.yml using config.yml.template as an example.")
         sys.exit()
     else:
-        logger.info('Configuration Found. Loading file.')  # print('Configuration Found. Loading file.')
-        with open(
-            config_file,
-            "r"
-        ) as ymlfile:
+        logger.info('Configuration Found. Loading file.')
+        # Ensure the modeline is present before parsing — a missing modeline is
+        # harmless to YAML loading, so we can safely write it first.  If the
+        # line is already there (or the user has their own local $schema
+        # override) the file is left unchanged.
+        ensure_schema_modeline(config_file, logger)
+        with open(config_file, "r") as ymlfile:
             cfg = yaml.load(
                 ymlfile,
                 Loader=yaml.BaseLoader
@@ -195,7 +259,7 @@ def ytdl_hooks_debug(d):
     logger = logging.getLogger('stream_harvestarr')
     if d['status'] == 'finished':
         file_tuple = os.path.split(os.path.abspath(d['filename']))
-        logger.info("      Done downloading {}".format(file_tuple[1]))  # print("Done downloading {}".format(file_tuple[1]))
+        logger.info("      Done downloading {}".format(file_tuple[1]))
     if d['status'] == 'downloading':
         progress = "      {} - {} - {}".format(d['filename'], d['_percent_str'], d['_eta_str'])
         logger.debug(progress)
@@ -206,6 +270,7 @@ def ytdl_hooks(d):
     if d['status'] == 'finished':
         file_tuple = os.path.split(os.path.abspath(d['filename']))
         logger.info("      Downloaded - {}".format(file_tuple[1]))
+
 
 def setup_logging(lf_enabled=True, lc_enabled=True, debugging=False):
     log_level = logging.INFO

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -24,6 +24,10 @@ cp config.yml.template config.yml
 nano config.yml
 ```
 
+### Editor Validation
+
+Stream Harvestarr automatically adds a `yaml-language-server` modeline to your `config.yml` on first run, enabling validation in supported editors.
+
 ### Protecting the config file
 
 `config.yml` holds plaintext secrets — the Sonarr `apikey` and any per-series `password` / `cookies_file` you configure. Restrict its permissions so other users on the host can't read it, and never commit it to a repository:

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -117,8 +117,11 @@ You should see:
 ```
 INFO - Initial run
 INFO - Scan interval set to every X minutes
-INFO - Exponential backoff enabled for rate limiting  # New feature active
+INFO - Exponential backoff enabled for rate limiting  # v1.3+
+INFO - Added yaml-language-server schema modeline to /config/config.yml  # v1.8+, first run only
 ```
+
+> **Note:** The schema modeline log line only appears once — on the first run after upgrading, or whenever a `config.yml` is missing the modeline. Subsequent runs will not log it.
 
 ## Post-Upgrade Configuration
 
@@ -302,6 +305,13 @@ streamharvestarr:
 Both work, but `streamharvestarr:` is recommended for future compatibility.
 
 ## Version-Specific Notes
+
+### v1.8.x
+- Added `services` — define shared credentials, cookies, subtitles, and offsets once and inherit across multiple series
+- Added JSON Schema (`config-schema.json`) for full config validation
+- Added automatic `yaml-language-server` modeline injection into `config.yml` — editors validate the file in real time with no manual setup
+- Schema modeline is injected on first run and is idempotent; existing modelines (including local overrides) are never overwritten
+- Fully backward compatible
 
 ### v1.3.x
 - Added rate limiting features


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows the Angular guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: N/A

`config.yml` has no schema attached. Editors open it as plain YAML with no validation, no autocomplete, and no hover documentation. Config mistakes (unknown keys, wrong value types, unquoted numeric API keys) are only caught at container startup when Stream Harvestarr exits with an error.

## What is the new behavior?

### JSON Schema (`config-schema.json`)

A JSON Schema (draft-07) is added at `app/config-schema.json` covering every configuration key:

- `streamharvestarr` — all 8 settings with type constraints and minimums
- `sonarr` — required fields enforced, `port` range, `basedir` pattern, `version` enum
- `ytdl` — `merge_output_format` restricted to the 6 valid container types
- `services` — new top-level array; each entry requires `title` + `url` plus any of the 8 inheritable keys
- `series` — `oneOf` two shapes:
  - **Standalone**: requires an absolute URI `url`, no `service` key
  - **Service-linked**: requires `service` name + relative `url` path
- All inheritable keys (`cookies_file`, `username`/`password`, `format`, `playlistreverse`, `offset`, `subtitles`, `regex`) validated in both `services` entries and `series` entries
- `username`/`password` dependency constraint — both or neither
- `additionalProperties: false` on every object so typos surface immediately

### Automatic modeline injection (`utils.py`)

`checkconfig()` now calls `ensure_schema_modeline()` before parsing `config.yml`. On first run (or any run where the line is absent) it prepends:

```
# yaml-language-server: $schema=https://raw.githubusercontent.com/ryakel/stream-harvestarr/main/app/config-schema.json
## Do not remove the above line
```

The function is idempotent — if any `yaml-language-server:` comment is already present (including a user's local `$schema` override) the file is left unchanged. The modeline is also injected into `config.yml.template` when it is first copied, so users see validation from the moment they open the template.

### Wiki documentation updated

- **Configuration.md** — new `Editor Validation` section explaining the modeline, editor benefits, and local override instructions
- **Upgrading.md** — `v1.8.x` version notes added; "Verify Upgrade" log block updated with the modeline injection log line

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
The `ensure_schema_modeline()` function degrades gracefully on permission errors (logs a warning, continues) and never mutates a file it cannot cleanly read back. Existing configs with no modeline are updated transparently on the next container start.