### PR TITLE
feat(app): derive season and episode zero-padding from Sonarr naming config

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -159,6 +159,57 @@ class StreamHarvester(object):
         except Exception:
             sys.exit("Error with ytdl config.yml values.")
 
+        # Sonarr's naming config controls zero-padding (e.g. Season {season:00}).
+        # Read it once at startup so downloaded paths match the user's media layout.
+        try:
+            naming = self.get_naming_config()
+            season_folder_format = naming.get('seasonFolderFormat') or 'Season {season}'
+            episode_format = naming.get('standardEpisodeFormat') or ''
+            self.season_padding = self.parse_number_format(season_folder_format, 'season')
+            self.episode_padding = self.parse_number_format(episode_format, 'episode')
+            logger.debug('Sonarr seasonFolderFormat: {} -> season padding width: {}'.format(
+                season_folder_format, self.season_padding
+            ))
+            logger.debug('Sonarr standardEpisodeFormat: {} -> episode padding width: {}'.format(
+                episode_format, self.episode_padding
+            ))
+        except Exception:
+            logger.warning('Could not retrieve Sonarr naming config, defaulting to no padding')
+            self.season_padding = 0
+            self.episode_padding = 0
+
+    def get_naming_config(self):
+        """Return Sonarr naming configuration including season folder format"""
+        logger.debug('Begin call Sonarr for naming config')
+        res = self.request_get("{}/{}/config/naming".format(
+            self.base_url,
+            self.sonarr_api_version
+        ))
+        return res.json()
+
+    def parse_number_format(self, format_string, token):
+        """Derive zero-padding width from a Sonarr format token.
+
+        e.g. parse_number_format('S{season:00}E{episode:00}', 'episode') -> 2
+             parse_number_format('S{season}E{episode}', 'episode') -> 0
+
+        Capped at 10 so a malformed format string can't cause unbounded zfill.
+        """
+        match = re.search(r'\{{{}(?::(0+))?\}}'.format(token), format_string)
+        if match and match.group(1):
+            return min(len(match.group(1)), 10)
+        return 0
+
+    def format_season(self, season_number):
+        if self.season_padding > 0:
+            return str(season_number).zfill(self.season_padding)
+        return str(season_number)
+
+    def format_episode(self, episode_number):
+        if self.episode_padding > 0:
+            return str(episode_number).zfill(self.episode_padding)
+        return str(episode_number)
+
     def get_episodes_by_series_id(self, series_id):
         """Returns all episodes for the given series"""
         logger.debug('Begin call Sonarr for all episodes for series_id: {}'.format(series_id))
@@ -550,15 +601,17 @@ class StreamHarvester(object):
                         found, dlurl = self.ytsearch(ydleps, url)
                         if found:
                             logger.info("    {}: Found - {}:".format(e + 1, eps['title']))
+                            season = self.format_season(eps['seasonNumber'])
+                            episode = self.format_episode(eps['episodeNumber'])
                             ytdl_format_options = {
                                 'format': self.ytdl_format,
                                 'quiet': True,
                                 "merge_output_format": self.ytdl_merge_output_format,
                                 'outtmpl': '/sonarr_root{0}/Season {1}/{2} - S{1}E{3} - {4} WEBDL.%(ext)s'.format(
                                     ser['path'],
-                                    eps['seasonNumber'],
+                                    season,
                                     ser['title'],
-                                    eps['episodeNumber'],
+                                    episode,
                                     eps['title']
                                 ),
                                 'progress_hooks': [ytdl_hooks],

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -161,18 +161,15 @@ class StreamHarvester(object):
 
         # Sonarr's naming config controls zero-padding (e.g. Season {season:00}).
         # Read it once at startup so downloaded paths match the user's media layout.
+        # Format strings themselves are not logged: CodeQL flags any value derived
+        # from a Sonarr API response as a potential credential leak (the request
+        # carries apikey=), and the format string isn't worth a per-line suppression.
         try:
             naming = self.get_naming_config()
             season_folder_format = naming.get('seasonFolderFormat') or 'Season {season}'
             episode_format = naming.get('standardEpisodeFormat') or ''
             self.season_padding = self.parse_number_format(season_folder_format, 'season')
             self.episode_padding = self.parse_number_format(episode_format, 'episode')
-            logger.debug('Sonarr seasonFolderFormat: {} -> season padding width: {}'.format(
-                season_folder_format, self.season_padding
-            ))
-            logger.debug('Sonarr standardEpisodeFormat: {} -> episode padding width: {}'.format(
-                episode_format, self.episode_padding
-            ))
         except Exception:
             logger.warning('Could not retrieve Sonarr naming config, defaulting to no padding')
             self.season_padding = 0

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -59,6 +59,18 @@ Comprehensive wiki documentation covering:
 - Troubleshooting guides
 - Advanced features
 
+### Sonarr-Aware Filename Padding (v1.8+)
+
+Downloaded filenames now respect Sonarr's configured season/episode
+padding. Default Sonarr installs use `S{season:00}E{episode:00}`, so new
+downloads will land as `S05E07` instead of `S5E7`. Folder paths follow
+Sonarr's `seasonFolderFormat` in the same way. The padding width is read
+from Sonarr at startup; if Sonarr is unreachable the previous unpadded
+behaviour is preserved.
+
+Existing files are not renamed — this only affects newly downloaded
+episodes.
+
 ## Upgrade Process
 
 ### Docker (Recommended)
@@ -302,6 +314,12 @@ streamharvestarr:
 Both work, but `streamharvestarr:` is recommended for future compatibility.
 
 ## Version-Specific Notes
+
+### v1.8.x
+- Downloaded filenames and folder paths now follow Sonarr's naming config
+  (zero-padding derived from `seasonFolderFormat` / `standardEpisodeFormat`)
+- Existing files are untouched; only new downloads are affected
+- Fully backward compatible — falls back to no padding if Sonarr is unreachable
 
 ### v1.3.x
 - Added rate limiting features


### PR DESCRIPTION
Supersedes #126.

The Sonarr-aware filename padding feature in #126 is a clear improvement (and you've already given it `intent: approved`), but the branch sat on a stale base and would have silently reverted ~130 lines of recently-merged code from #120, #122, #124, #127, #128, and #130. I rebuilt the feature on top of current `development` so only the intended additions land.

## What lands

Four new helpers on `StreamHarvester` and one block in `__init__`:

- `get_naming_config()` — calls Sonarr's `/config/naming` endpoint
- `parse_number_format(format_string, token)` — derives the zero-padding width from Sonarr's format string (e.g. `S{season:00}` → 2)
- `format_season(n)` / `format_episode(n)` — apply the derived padding via `zfill`
- `__init__` reads the config once at startup and stores `self.season_padding` / `self.episode_padding`; falls back to no padding if Sonarr is unreachable
- `download()` formats season/episode through the helpers before building the `outtmpl`

Net: +73 / -2 across `app/stream_harvestarr.py` and `wiki/Upgrading.md`. One file of feature code, one wiki note.

## Differences from #126

- **Rebuilt on current `development`** — does not revert `merge_service_config`, `appendcredentials`, the `normalize_title` apostrophe fix, the `isinstance(autosubs_raw, bool)` guard, or the `redact_sensitive` logging hardening.
- **Fixes a latent IndexError in #126's `outtmpl`** — the original PR renumbered the format placeholders to `{0}{1}{2}{3}{4}{5}` (6 slots) but only passed 5 args to `.format(...)`, so the first successful download would have crashed. This version keeps the original `{0}{1}{2}{1}{3}{4}` positional structure and just substitutes the padded season/episode in — minimal-invasive, no bug.
- **`parse_number_format` caps padding width at 10** as defense-in-depth so a malformed Sonarr response can't cause an unbounded `zfill` allocation.
- **Null-coalescing on `naming.get(...)`** — `dict.get(k, default)` doesn't fall back when the value is explicit `None`; using `or` covers both missing and null.
- **Wiki note added** to `wiki/Upgrading.md` under "Latest Features" and "Version-Specific Notes" — the filename-padding shift is a visible behavior change for users on default Sonarr settings (new downloads emit `S05E07` instead of `S5E7`), worth flagging in upgrade docs.

## Test plan

- [x] `ast.parse` on the modified file
- [x] 8 unit cases against `parse_number_format`, including realistic Sonarr formats, an empty string, 3-digit padding, and a 100-character malicious format (verified the 10-cap)
- [x] Null-coalescing verified across missing-key / explicit-null / empty-string / real-value cases
- [x] Rendered `outtmpl` verified end-to-end: `/sonarr_root/My Series/Season 05/My Series - S05E07 - Pilot WEBDL.%(ext)s`
- [ ] Manual verification against a real Sonarr — not feasible from CI; ideally the reviewer or @RedRubble can run on a live instance

Fixes #125
Co-authored-by: Rubble <69933306+RedRubble@users.noreply.github.com>