### PR TITLE
fix(app): stale datetime bug + non-root container preparation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,12 @@ RUN --mount=type=cache,target=/var/cache/apk,id=apk-${TARGETARCH},sharing=locked
     pip3 install -r requirements.txt && \
     apk del alpine-sdk
 
-# create ytdlp user so root isn't used
+# create ytdlp user so root isn't used (USER directive coming in a future release)
 RUN addgroup -g 1000 ytdlpg && \
 	adduser -u 911 -h /config -s /bin/false ytdlp -D && \
 	addgroup ytdlp ytdlpg && \
-# create necessary files / folders
-	mkdir -p /config /app /sonarr_root /logs /run/lock && \
-	touch /var/lock/sonarr_youtube.lock
+	mkdir -p /config /app /sonarr_root /logs && \
+	chown -R ytdlp:ytdlpg /config /logs
 
 # add volumes
 VOLUME /config

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ services:
   stream-harvestarr:
     image: ryakel/stream-harvestarr
     container_name: stream-harvestarr
+    # user: "1000:1000"  # match your host uid:gid — see wiki/Upgrading
     volumes:
       - /path/to/data:/config
       - /path/to/sonarrmedia:/sonarr_root

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -726,6 +726,14 @@ def main():
 
 
 if __name__ == "__main__":
+    if os.geteuid() == 0:
+        logger.warning(
+            'Container is running as root (uid 0). A future release will '
+            'switch to non-root by default (uid 911, the ytdlp user already '
+            'created in this image). To prepare: add "user: \'911:1000\'" to '
+            'your docker-compose, or run: chown -R 911:1000 <config-path> '
+            '<logs-path> on the host. See the wiki Upgrading guide for details.'
+        )
     logger.info('Initial run')
     main()
     schedule.every(int(SCANINTERVAL)).minutes.do(main)

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -20,7 +20,6 @@ args = parser.parse_args()
 logger = setup_logging(True, True, args.debug)
 
 date_format = "%Y-%m-%dT%H:%M:%SZ"
-now = datetime.now()
 
 CONFIGFILE = os.environ['CONFIGPATH']
 CONFIGPATH = CONFIGFILE.replace('config.yml', '')
@@ -420,6 +419,7 @@ class StreamHarvester(object):
         return matched
 
     def getseriesepisodes(self, series):
+        now = datetime.now()
         needed = []
         for ser in series[:]:
             episodes = self.get_episodes_by_series_id(ser['id'])

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -380,6 +380,32 @@ ls -la /path/to/logs
 docker logs stream-harvestarr --tail 50
 ```
 
+### Permission Denied on /config or /logs
+
+If you set `user:` in your compose file (or plan to when non-root becomes
+the default), the container process needs write access to its bind-mounted
+directories.
+
+**Fix ownership to match the container user:**
+```bash
+chown -R 911:1000 /path/to/config /path/to/logs
+```
+
+Or if you use a custom uid:
+```bash
+# use your own uid:gid
+chown -R 1000:1000 /path/to/config /path/to/logs
+```
+
+Then set `user: "1000:1000"` in your compose to match.
+
+### "Container is running as root" Warning
+
+This is a deprecation notice, not an error. The container still works
+normally as root. A future release will switch to non-root by default.
+See the [Upgrading guide](Upgrading#non-root-container-preparation-v18)
+for how to prepare.
+
 ## Log Analysis
 
 ### Enabling Debug Logging

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -71,6 +71,38 @@ behaviour is preserved.
 Existing files are not renamed — this only affects newly downloaded
 episodes.
 
+### Non-Root Container Preparation (v1.8+)
+
+The container currently runs as root. A future release will switch to
+non-root by default (uid 911 / gid 1000, using the `ytdlp` user that is
+already created in the image but not yet active).
+
+Starting in v1.8, the container logs a warning on every startup if it
+detects it is running as root. No behaviour changes yet — this is advance
+notice so you can prepare at your own pace.
+
+**To prepare now (optional, recommended):**
+
+1. Fix ownership on your bind-mounted directories:
+   ```bash
+   chown -R 911:1000 /path/to/config /path/to/logs
+   ```
+2. Add `user:` to your compose file:
+   ```yaml
+   services:
+     stream-harvestarr:
+       user: "911:1000"
+   ```
+   Or use your own host uid (e.g. `"1000:1000"`) and chown to match.
+
+3. Restart the container. If everything works, you're ready for the
+   future default and the startup warning disappears.
+
+**If you do nothing:** the container keeps running as root, exactly as
+before. The only change is the log warning. When the non-root default
+ships in a future release, users who haven't prepared will need to run
+the chown above before upgrading.
+
 ## Upgrade Process
 
 ### Docker (Recommended)
@@ -319,7 +351,11 @@ Both work, but `streamharvestarr:` is recommended for future compatibility.
 - Downloaded filenames and folder paths now follow Sonarr's naming config
   (zero-padding derived from `seasonFolderFormat` / `standardEpisodeFormat`)
 - Existing files are untouched; only new downloads are affected
-- Fully backward compatible — falls back to no padding if Sonarr is unreachable
+- Falls back to no padding if Sonarr is unreachable
+- Logs a deprecation warning if running as root — a future release will
+  default to non-root (uid 911). See [Non-Root Container Preparation](#non-root-container-preparation-v18)
+- Fixed stale `datetime.now()` bug inherited from upstream — episodes that
+  aired after container start are now detected without a restart
 
 ### v1.3.x
 - Added rate limiting features


### PR DESCRIPTION
Two independent fixes and the Phase 1 groundwork for switching to a non-root container default.

## Changes

### 1. Fix stale `datetime.now()` (inherited upstream bug)

`now = datetime.now()` was set once at module load and never refreshed. After the container ran for a while, episodes that aired since startup were skipped — `eps_date > now` evaluated against the stale value, making recently-aired episodes appear "future." Users had to restart the container to pick up new episodes.

Same bug reported as whatdaybob/sonarr_youtubedl#35 in the upstream project; fixed independently in the garwedgess fork.

**Fix:** move `datetime.now()` into `getseriesepisodes()` so it refreshes every scan cycle.

### 2. Fix CodeQL false positive

Dropped two `logger.debug` calls that interpolated Sonarr's naming-config format strings. CodeQL's `py/clear-text-logging-sensitive-data` flagged them because the HTTP call to Sonarr carries `apikey=` in the query string, tainting the entire response as "sensitive." Same false-positive shape as commit `7724684`.

### 3. Non-root container preparation (Phase 1 — non-breaking)

The Dockerfile has always created a `ytdlp` user (uid 911 / gid 1000) but never activated it — the container runs as root despite the comment saying otherwise. This is Phase 1 of a two-phase transition to non-root by default.

**What ships now (zero breaking changes):**
- **Runtime deprecation warning:** logs a `WARNING` on every startup if `os.geteuid() == 0`, with actionable instructions (add `user:` to compose, chown host dirs)
- **Build-time `chown`:** `/config` and `/logs` are now owned by `ytdlp:ytdlpg` in the image layer, so anonymous volumes get correct ownership automatically
- **Dead code removed:** `/run/lock` mkdir and `/var/lock/sonarr_youtube.lock` touch were never referenced from application code
- **Docs:** README compose example has a commented-out `user:` line; wiki/Upgrading.md has a "Non-Root Container Preparation" section; wiki/Troubleshooting.md has "Permission Denied" and "running as root warning" entries

**What ships later (Phase 2, future release):**
- One line: `USER ytdlp` in the Dockerfile
- Users who prepped in Phase 1 get a drop-in upgrade
- Users who didn't get a clear error with a documented fix

## Test plan

- [x] `ast.parse` syntax check
- [x] `os.geteuid()` warning renders cleanly at runtime (tested in isolation)
- [x] `now` is no longer module-level — only local in `getseriesepisodes()`
- [x] Dead lock-file code removed (0 matches for `run/lock` or `sonarr_youtube.lock` in Dockerfile)
- [x] Build-time `chown` present in Dockerfile
- [x] README compose example has commented `user:` line
- [ ] CI: build + smoke test + CodeQL