### PR TITLE
chore: promote development to main (v1.8.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,12 @@ RUN --mount=type=cache,target=/var/cache/apk,id=apk-${TARGETARCH},sharing=locked
     pip3 install -r requirements.txt && \
     apk del alpine-sdk
 
-# create ytdlp user so root isn't used
+# create ytdlp user so root isn't used (USER directive coming in a future release)
 RUN addgroup -g 1000 ytdlpg && \
 	adduser -u 911 -h /config -s /bin/false ytdlp -D && \
 	addgroup ytdlp ytdlpg && \
-# create necessary files / folders
-	mkdir -p /config /app /sonarr_root /logs /run/lock && \
-	touch /var/lock/sonarr_youtube.lock
+	mkdir -p /config /app /sonarr_root /logs && \
+	chown -R ytdlp:ytdlpg /config /logs
 
 # add volumes
 VOLUME /config

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ services:
   stream-harvestarr:
     image: ryakel/stream-harvestarr
     container_name: stream-harvestarr
+    # user: "1000:1000"  # match your host uid:gid — see wiki/Upgrading
     volumes:
       - /path/to/data:/config
       - /path/to/sonarrmedia:/sonarr_root

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -159,6 +159,57 @@ class StreamHarvester(object):
         except Exception:
             sys.exit("Error with ytdl config.yml values.")
 
+        # Sonarr's naming config controls zero-padding (e.g. Season {season:00}).
+        # Read it once at startup so downloaded paths match the user's media layout.
+        try:
+            naming = self.get_naming_config()
+            season_folder_format = naming.get('seasonFolderFormat') or 'Season {season}'
+            episode_format = naming.get('standardEpisodeFormat') or ''
+            self.season_padding = self.parse_number_format(season_folder_format, 'season')
+            self.episode_padding = self.parse_number_format(episode_format, 'episode')
+            logger.debug('Sonarr seasonFolderFormat: {} -> season padding width: {}'.format(
+                season_folder_format, self.season_padding
+            ))
+            logger.debug('Sonarr standardEpisodeFormat: {} -> episode padding width: {}'.format(
+                episode_format, self.episode_padding
+            ))
+        except Exception:
+            logger.warning('Could not retrieve Sonarr naming config, defaulting to no padding')
+            self.season_padding = 0
+            self.episode_padding = 0
+
+    def get_naming_config(self):
+        """Return Sonarr naming configuration including season folder format"""
+        logger.debug('Begin call Sonarr for naming config')
+        res = self.request_get("{}/{}/config/naming".format(
+            self.base_url,
+            self.sonarr_api_version
+        ))
+        return res.json()
+
+    def parse_number_format(self, format_string, token):
+        """Derive zero-padding width from a Sonarr format token.
+
+        e.g. parse_number_format('S{season:00}E{episode:00}', 'episode') -> 2
+             parse_number_format('S{season}E{episode}', 'episode') -> 0
+
+        Capped at 10 so a malformed format string can't cause unbounded zfill.
+        """
+        match = re.search(r'\{{{}(?::(0+))?\}}'.format(token), format_string)
+        if match and match.group(1):
+            return min(len(match.group(1)), 10)
+        return 0
+
+    def format_season(self, season_number):
+        if self.season_padding > 0:
+            return str(season_number).zfill(self.season_padding)
+        return str(season_number)
+
+    def format_episode(self, episode_number):
+        if self.episode_padding > 0:
+            return str(episode_number).zfill(self.episode_padding)
+        return str(episode_number)
+
     def get_episodes_by_series_id(self, series_id):
         """Returns all episodes for the given series"""
         logger.debug('Begin call Sonarr for all episodes for series_id: {}'.format(series_id))
@@ -550,15 +601,17 @@ class StreamHarvester(object):
                         found, dlurl = self.ytsearch(ydleps, url)
                         if found:
                             logger.info("    {}: Found - {}:".format(e + 1, eps['title']))
+                            season = self.format_season(eps['seasonNumber'])
+                            episode = self.format_episode(eps['episodeNumber'])
                             ytdl_format_options = {
                                 'format': self.ytdl_format,
                                 'quiet': True,
                                 "merge_output_format": self.ytdl_merge_output_format,
                                 'outtmpl': '/sonarr_root{0}/Season {1}/{2} - S{1}E{3} - {4} WEBDL.%(ext)s'.format(
                                     ser['path'],
-                                    eps['seasonNumber'],
+                                    season,
                                     ser['title'],
-                                    eps['episodeNumber'],
+                                    episode,
                                     eps['title']
                                 ),
                                 'progress_hooks': [ytdl_hooks],

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -161,18 +161,15 @@ class StreamHarvester(object):
 
         # Sonarr's naming config controls zero-padding (e.g. Season {season:00}).
         # Read it once at startup so downloaded paths match the user's media layout.
+        # Format strings themselves are not logged: CodeQL flags any value derived
+        # from a Sonarr API response as a potential credential leak (the request
+        # carries apikey=), and the format string isn't worth a per-line suppression.
         try:
             naming = self.get_naming_config()
             season_folder_format = naming.get('seasonFolderFormat') or 'Season {season}'
             episode_format = naming.get('standardEpisodeFormat') or ''
             self.season_padding = self.parse_number_format(season_folder_format, 'season')
             self.episode_padding = self.parse_number_format(episode_format, 'episode')
-            logger.debug('Sonarr seasonFolderFormat: {} -> season padding width: {}'.format(
-                season_folder_format, self.season_padding
-            ))
-            logger.debug('Sonarr standardEpisodeFormat: {} -> episode padding width: {}'.format(
-                episode_format, self.episode_padding
-            ))
         except Exception:
             logger.warning('Could not retrieve Sonarr naming config, defaulting to no padding')
             self.season_padding = 0

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -726,6 +726,14 @@ def main():
 
 
 if __name__ == "__main__":
+    if os.geteuid() == 0:
+        logger.warning(
+            'Container is running as root (uid 0). A future release will '
+            'switch to non-root by default (uid 911, the ytdlp user already '
+            'created in this image). To prepare: add "user: \'911:1000\'" to '
+            'your docker-compose, or run: chown -R 911:1000 <config-path> '
+            '<logs-path> on the host. See the wiki Upgrading guide for details.'
+        )
     logger.info('Initial run')
     main()
     schedule.every(int(SCANINTERVAL)).minutes.do(main)

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -20,7 +20,6 @@ args = parser.parse_args()
 logger = setup_logging(True, True, args.debug)
 
 date_format = "%Y-%m-%dT%H:%M:%SZ"
-now = datetime.now()
 
 CONFIGFILE = os.environ['CONFIGPATH']
 CONFIGPATH = CONFIGFILE.replace('config.yml', '')
@@ -420,6 +419,7 @@ class StreamHarvester(object):
         return matched
 
     def getseriesepisodes(self, series):
+        now = datetime.now()
         needed = []
         for ser in series[:]:
             episodes = self.get_episodes_by_series_id(ser['id'])

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -380,6 +380,32 @@ ls -la /path/to/logs
 docker logs stream-harvestarr --tail 50
 ```
 
+### Permission Denied on /config or /logs
+
+If you set `user:` in your compose file (or plan to when non-root becomes
+the default), the container process needs write access to its bind-mounted
+directories.
+
+**Fix ownership to match the container user:**
+```bash
+chown -R 911:1000 /path/to/config /path/to/logs
+```
+
+Or if you use a custom uid:
+```bash
+# use your own uid:gid
+chown -R 1000:1000 /path/to/config /path/to/logs
+```
+
+Then set `user: "1000:1000"` in your compose to match.
+
+### "Container is running as root" Warning
+
+This is a deprecation notice, not an error. The container still works
+normally as root. A future release will switch to non-root by default.
+See the [Upgrading guide](Upgrading#non-root-container-preparation-v18)
+for how to prepare.
+
 ## Log Analysis
 
 ### Enabling Debug Logging

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -59,6 +59,18 @@ Comprehensive wiki documentation covering:
 - Troubleshooting guides
 - Advanced features
 
+### Sonarr-Aware Filename Padding (v1.8+)
+
+Downloaded filenames now respect Sonarr's configured season/episode
+padding. Default Sonarr installs use `S{season:00}E{episode:00}`, so new
+downloads will land as `S05E07` instead of `S5E7`. Folder paths follow
+Sonarr's `seasonFolderFormat` in the same way. The padding width is read
+from Sonarr at startup; if Sonarr is unreachable the previous unpadded
+behaviour is preserved.
+
+Existing files are not renamed — this only affects newly downloaded
+episodes.
+
 ## Upgrade Process
 
 ### Docker (Recommended)
@@ -302,6 +314,12 @@ streamharvestarr:
 Both work, but `streamharvestarr:` is recommended for future compatibility.
 
 ## Version-Specific Notes
+
+### v1.8.x
+- Downloaded filenames and folder paths now follow Sonarr's naming config
+  (zero-padding derived from `seasonFolderFormat` / `standardEpisodeFormat`)
+- Existing files are untouched; only new downloads are affected
+- Fully backward compatible — falls back to no padding if Sonarr is unreachable
 
 ### v1.3.x
 - Added rate limiting features

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -71,6 +71,38 @@ behaviour is preserved.
 Existing files are not renamed — this only affects newly downloaded
 episodes.
 
+### Non-Root Container Preparation (v1.8+)
+
+The container currently runs as root. A future release will switch to
+non-root by default (uid 911 / gid 1000, using the `ytdlp` user that is
+already created in the image but not yet active).
+
+Starting in v1.8, the container logs a warning on every startup if it
+detects it is running as root. No behaviour changes yet — this is advance
+notice so you can prepare at your own pace.
+
+**To prepare now (optional, recommended):**
+
+1. Fix ownership on your bind-mounted directories:
+   ```bash
+   chown -R 911:1000 /path/to/config /path/to/logs
+   ```
+2. Add `user:` to your compose file:
+   ```yaml
+   services:
+     stream-harvestarr:
+       user: "911:1000"
+   ```
+   Or use your own host uid (e.g. `"1000:1000"`) and chown to match.
+
+3. Restart the container. If everything works, you're ready for the
+   future default and the startup warning disappears.
+
+**If you do nothing:** the container keeps running as root, exactly as
+before. The only change is the log warning. When the non-root default
+ships in a future release, users who haven't prepared will need to run
+the chown above before upgrading.
+
 ## Upgrade Process
 
 ### Docker (Recommended)
@@ -319,7 +351,11 @@ Both work, but `streamharvestarr:` is recommended for future compatibility.
 - Downloaded filenames and folder paths now follow Sonarr's naming config
   (zero-padding derived from `seasonFolderFormat` / `standardEpisodeFormat`)
 - Existing files are untouched; only new downloads are affected
-- Fully backward compatible — falls back to no padding if Sonarr is unreachable
+- Falls back to no padding if Sonarr is unreachable
+- Logs a deprecation warning if running as root — a future release will
+  default to non-root (uid 911). See [Non-Root Container Preparation](#non-root-container-preparation-v18)
+- Fixed stale `datetime.now()` bug inherited from upstream — episodes that
+  aired after container start are now detected without a restart
 
 ### v1.3.x
 - Added rate limiting features


### PR DESCRIPTION
Promotes `development` to `main` for the v1.8.0 release.

## What's included

### Features
- **Sonarr-aware filename padding** — downloads respect Sonarr's configured season/episode zero-padding (`S05E07` instead of `S5E7`). Fixes #125. Co-authored-by: @RedRubble

### Bug Fixes
- **Stale episode detection** — `datetime.now()` refreshed every scan cycle instead of once at container start (upstream bug whatdaybob/sonarr_youtubedl#35)
- **CodeQL false positive** — removed taint-flagged debug log lines

### Non-Root Container Preparation (Phase 1 — non-breaking)
- Deprecation warning on startup if running as root
- Build-time ownership of `/config` and `/logs` set to `ytdlp:ytdlpg`
- Dead lock-file code removed
- README, wiki/Upgrading, wiki/Troubleshooting updated

**No breaking changes.** Container still runs as root. Non-root default coming in a future release.

4 commits, 5 files, +145 / -7