### PR TITLE
fix(app): remove unreachable except handlers in config parsing

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -123,21 +123,17 @@ class StreamHarvester(object):
         except Exception as e:
             sys.exit("Error with sonarr config.yml values: {e}")
 
-        # Series Setup
+        # YTDL Setup
         try:
             self.ytdl_format = cfg['ytdl']['default_format']
-        except Exception:
-            sys.exit("Error with ytdl config.yml values.")
         except Exception as e:
             sys.exit(f"Error with ytdl config.yml values: {e}")
 
-        # YTDL Setup
+        # Series Setup
         try:
             self.series = cfg["series"]
-        except Exception:
-            sys.exit("Error with series config.yml values.")
         except Exception as e:
-            sys.exit("Error with series config.yml values: {e}")
+            sys.exit(f"Error with series config.yml values: {e}")
 
         # Services setup - optional, provides base config for series to inherit from
         try:


### PR DESCRIPTION
## What this does

Follow-up cleanup surfaced during the review of #140, scoped to the issues that were **out of scope** for that PR.

The `ConfigManager` config-parsing blocks for `ytdl` and `series` each had two `except Exception` clauses:

```python
try:
    self.ytdl_format = cfg['ytdl']['default_format']
except Exception:                 # catches everything...
    sys.exit("Error with ytdl config.yml values.")
except Exception as e:            # ...so this is unreachable dead code
    sys.exit(f"Error with ytdl config.yml values: {e}")
```

The first bare `except Exception:` always wins, so the more informative `except Exception as e:` handler can never run. This change collapses each block to the single informative handler.

While in those exact lines, this also:
- **Fixes a missing `f` prefix** on the `series` handler (`"...: {e}"` → `f"...: {e}"`), which was printing the literal `{e}` instead of the exception.
- **Corrects two swapped section comments** — `# Series Setup` was sitting above the `ytdl` block and `# YTDL Setup` above the `series` block.

## Scope

Deliberately does **not** touch the `sonarr` config block, which has the identical duplicate-`except` pattern — that block is fixed independently by #140. Keeping the two changes non-overlapping avoids a merge conflict regardless of merge order.

## Type

- [x] Bugfix (dead code / broken error interpolation)

## Testing

- `python3 -m py_compile app/stream_harvestarr.py` passes.
- No behavior change on the happy path; on a config error the process now exits with the actual exception detail instead of a generic message (ytdl/series) — which was the original intent of the `as e` handlers.

Relates to the review of #140.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqSNrwH2dWR96cL25Y5KU5)_