### PR TITLE
refactor(app): bind root_folder test to shipped normalization logic

### DIFF
--- a/app/pathutils.py
+++ b/app/pathutils.py
@@ -1,0 +1,23 @@
+"""Pure path helpers shared between the app and its unit tests.
+
+This module is deliberately free of import-time side effects (no env-var
+reads, no argument parsing) so it can be imported directly from tests --
+unlike ``stream_harvestarr.py`` and ``utils.py``, which both read
+``os.environ['CONFIGPATH']`` at module load and therefore can't be imported
+in a bare test environment.
+"""
+
+# Default download-path prefix, preserved for backward compatibility with the
+# original hardcoded ``/sonarr_root`` mount point (see issue #137).
+DEFAULT_ROOT_FOLDER = '/sonarr_root'
+
+
+def normalize_root_folder(raw_value):
+    """Normalize a configured ``root_folder`` value.
+
+    - An explicit empty string stays ``''`` -- meaning "use Sonarr's absolute
+      path directly, with no prefix" (the TRaSH Guides same-path layout).
+    - Any other value has its trailing slashes stripped so that ``/data`` and
+      ``/data/`` behave identically.
+    """
+    return '' if raw_value == '' else raw_value.rstrip('/')

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 from utils import upperescape, normalize_title, checkconfig, offsethandler, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
+from pathutils import normalize_root_folder, DEFAULT_ROOT_FOLDER
 from datetime import datetime
 import schedule
 import time
@@ -119,10 +120,10 @@ class StreamHarvester(object):
             self.sonarr_api_version = api
             self.api_key = cfg['sonarr']['apikey']
             # Handle root_folder: default to /sonarr_root for backward compat,
-            # but allow empty string (no prefix) or custom path. Strip trailing
-            # slash unless the value is explicitly empty (meaning use abs path).
-            raw = cfg['sonarr'].get('root_folder', '/sonarr_root')
-            self.root_folder = '' if raw == '' else raw.rstrip('/')
+            # but allow empty string (no prefix) or custom path. Normalization
+            # lives in pathutils.normalize_root_folder so it can be unit-tested.
+            raw = cfg['sonarr'].get('root_folder', DEFAULT_ROOT_FOLDER)
+            self.root_folder = normalize_root_folder(raw)
         except Exception as e:
             sys.exit(f"Error with sonarr config.yml values: {e}")
 

--- a/test/test_root_folder_normalization.py
+++ b/test/test_root_folder_normalization.py
@@ -1,18 +1,18 @@
 """
 Unit tests for root_folder normalization logic.
-Tests the three key cases: default (unset), explicit empty, and trailing-slash stripping.
+
+These exercise the *actual* helper used by the application
+(``pathutils.normalize_root_folder``) rather than a local copy, so the test
+stays bound to the shipped code path.
 """
+import os
+import sys
 import unittest
 
+# pathutils lives in the app/ directory alongside stream_harvestarr.py.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'app'))
 
-def normalize_root_folder(raw_value):
-    """
-    Normalize root_folder value from config.
-    - Default (unset): returns /sonarr_root
-    - Explicit empty string: returns ''
-    - Trailing slash: strips it
-    """
-    return '' if raw_value == '' else raw_value.rstrip('/')
+from pathutils import normalize_root_folder, DEFAULT_ROOT_FOLDER  # noqa: E402
 
 
 class TestRootFolderNormalization(unittest.TestCase):
@@ -20,38 +20,33 @@ class TestRootFolderNormalization(unittest.TestCase):
 
     def test_default_unset_returns_sonarr_root(self):
         """Default case: unset root_folder should normalize to /sonarr_root."""
-        raw = '/sonarr_root'  # default from .get('root_folder', '/sonarr_root')
-        result = normalize_root_folder(raw)
+        # Mirrors __init__: cfg['sonarr'].get('root_folder', DEFAULT_ROOT_FOLDER)
+        result = normalize_root_folder(DEFAULT_ROOT_FOLDER)
         self.assertEqual(result, '/sonarr_root')
 
     def test_explicit_empty_string_returns_empty(self):
         """Empty string case: '' should remain ''."""
-        raw = ''
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('')
         self.assertEqual(result, '')
 
     def test_trailing_slash_stripped(self):
         """Trailing slash case: /sonarr_root/ should become /sonarr_root."""
-        raw = '/sonarr_root/'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/sonarr_root/')
         self.assertEqual(result, '/sonarr_root')
 
     def test_custom_path_with_trailing_slash_stripped(self):
         """Custom path with trailing slash should be stripped."""
-        raw = '/custom/path/'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/custom/path/')
         self.assertEqual(result, '/custom/path')
 
     def test_custom_path_without_trailing_slash_unchanged(self):
         """Custom path without trailing slash should remain unchanged."""
-        raw = '/custom/path'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/custom/path')
         self.assertEqual(result, '/custom/path')
 
     def test_multiple_trailing_slashes_all_stripped(self):
         """Multiple trailing slashes should all be stripped."""
-        raw = '/sonarr_root///'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/sonarr_root///')
         self.assertEqual(result, '/sonarr_root')
 
 


### PR DESCRIPTION
## What this does

Follow-up to the note from #140's review: the unit test added there reimplemented `normalize_root_folder()` as a **local copy**, so it exercised a duplicate of the logic rather than the actual code path. If the inline expression in `ConfigManager.__init__` ever drifted, the test would keep passing — false confidence.

The logic couldn't simply be imported because both `stream_harvestarr.py` and `utils.py` read `os.environ['CONFIGPATH']` at import time, so importing them in a bare test environment blows up.

## Change

- New **`app/pathutils.py`** — a deliberately side-effect-free module (no env reads, no arg parsing) exposing `normalize_root_folder()` and `DEFAULT_ROOT_FOLDER`, so it's safe to import from tests.
- `ConfigManager.__init__` now calls `normalize_root_folder(raw)` instead of inlining `'' if raw == '' else raw.rstrip('/')`.
- `test/test_root_folder_normalization.py` now **imports the real helper** instead of redefining it.

## Behavior

No functional change — pure refactor for testability.

- `python3 -m unittest discover -s test` → **6/6 pass** against the shipped helper.
- `py_compile` clean on `stream_harvestarr.py` + `pathutils.py`.
- Helper imports cleanly with no `CONFIGPATH` set.

Relates to the review follow-up on #140.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqSNrwH2dWR96cL25Y5KU5)_