### PR TITLE
release: root_folder config + config-parsing cleanup

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -15,6 +15,9 @@ sonarr:
     ssl: false
     # basedir: '/sonarr'  # if you have sonarr running with a basedir set (e.g. behind a proxy)
     # version: v4 # if running v4 beta, allows the v3 api endpoints
+    # root_folder: '/sonarr_root'  # path prefix for downloads (default: /sonarr_root)
+                                   # set to '' (empty) for TRaSH Guides setup with same-path mounts
+                                   # see wiki Configuration.md for details
 
 ytdl:
   # For information on format refer to https://github.com/ytdl-org/youtube-dl#format-selection

--- a/app/pathutils.py
+++ b/app/pathutils.py
@@ -1,0 +1,23 @@
+"""Pure path helpers shared between the app and its unit tests.
+
+This module is deliberately free of import-time side effects (no env-var
+reads, no argument parsing) so it can be imported directly from tests --
+unlike ``stream_harvestarr.py`` and ``utils.py``, which both read
+``os.environ['CONFIGPATH']`` at module load and therefore can't be imported
+in a bare test environment.
+"""
+
+# Default download-path prefix, preserved for backward compatibility with the
+# original hardcoded ``/sonarr_root`` mount point (see issue #137).
+DEFAULT_ROOT_FOLDER = '/sonarr_root'
+
+
+def normalize_root_folder(raw_value):
+    """Normalize a configured ``root_folder`` value.
+
+    - An explicit empty string stays ``''`` -- meaning "use Sonarr's absolute
+      path directly, with no prefix" (the TRaSH Guides same-path layout).
+    - Any other value has its trailing slashes stripped so that ``/data`` and
+      ``/data/`` behave identically.
+    """
+    return '' if raw_value == '' else raw_value.rstrip('/')

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -118,8 +118,11 @@ class StreamHarvester(object):
             )
             self.sonarr_api_version = api
             self.api_key = cfg['sonarr']['apikey']
-        except Exception:
-            sys.exit("Error with sonarr config.yml values.")
+            # Handle root_folder: default to /sonarr_root for backward compat,
+            # but allow empty string (no prefix) or custom path. Strip trailing
+            # slash unless the value is explicitly empty (meaning use abs path).
+            raw = cfg['sonarr'].get('root_folder', '/sonarr_root')
+            self.root_folder = '' if raw == '' else raw.rstrip('/')
         except Exception as e:
             sys.exit("Error with sonarr config.yml values: {e}")
 
@@ -604,7 +607,8 @@ class StreamHarvester(object):
                                 'format': self.ytdl_format,
                                 'quiet': True,
                                 "merge_output_format": self.ytdl_merge_output_format,
-                                'outtmpl': '/sonarr_root{0}/Season {1}/{2} - S{1}E{3} - {4} WEBDL.%(ext)s'.format(
+                                'outtmpl': '{0}{1}/Season {2}/{3} - S{2}E{4} - {5} WEBDL.%(ext)s'.format(
+                                    self.root_folder,
                                     ser['path'],
                                     season,
                                     ser['title'],

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -123,21 +123,17 @@ class StreamHarvester(object):
         except Exception as e:
             sys.exit("Error with sonarr config.yml values: {e}")
 
-        # Series Setup
+        # YTDL Setup
         try:
             self.ytdl_format = cfg['ytdl']['default_format']
-        except Exception:
-            sys.exit("Error with ytdl config.yml values.")
         except Exception as e:
             sys.exit(f"Error with ytdl config.yml values: {e}")
 
-        # YTDL Setup
+        # Series Setup
         try:
             self.series = cfg["series"]
-        except Exception:
-            sys.exit("Error with series config.yml values.")
         except Exception as e:
-            sys.exit("Error with series config.yml values: {e}")
+            sys.exit(f"Error with series config.yml values: {e}")
 
         # Services setup - optional, provides base config for series to inherit from
         try:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 from utils import upperescape, normalize_title, checkconfig, offsethandler, YoutubeDLLogger, ytdl_hooks, ytdl_hooks_debug, setup_logging  # NOQA
+from pathutils import normalize_root_folder, DEFAULT_ROOT_FOLDER
 from datetime import datetime
 import schedule
 import time
@@ -119,10 +120,10 @@ class StreamHarvester(object):
             self.sonarr_api_version = api
             self.api_key = cfg['sonarr']['apikey']
             # Handle root_folder: default to /sonarr_root for backward compat,
-            # but allow empty string (no prefix) or custom path. Strip trailing
-            # slash unless the value is explicitly empty (meaning use abs path).
-            raw = cfg['sonarr'].get('root_folder', '/sonarr_root')
-            self.root_folder = '' if raw == '' else raw.rstrip('/')
+            # but allow empty string (no prefix) or custom path. Normalization
+            # lives in pathutils.normalize_root_folder so it can be unit-tested.
+            raw = cfg['sonarr'].get('root_folder', DEFAULT_ROOT_FOLDER)
+            self.root_folder = normalize_root_folder(raw)
         except Exception as e:
             sys.exit(f"Error with sonarr config.yml values: {e}")
 

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -124,7 +124,7 @@ class StreamHarvester(object):
             raw = cfg['sonarr'].get('root_folder', '/sonarr_root')
             self.root_folder = '' if raw == '' else raw.rstrip('/')
         except Exception as e:
-            sys.exit("Error with sonarr config.yml values: {e}")
+            sys.exit(f"Error with sonarr config.yml values: {e}")
 
         # YTDL Setup
         try:

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -126,21 +126,17 @@ class StreamHarvester(object):
         except Exception as e:
             sys.exit("Error with sonarr config.yml values: {e}")
 
-        # Series Setup
+        # YTDL Setup
         try:
             self.ytdl_format = cfg['ytdl']['default_format']
-        except Exception:
-            sys.exit("Error with ytdl config.yml values.")
         except Exception as e:
             sys.exit(f"Error with ytdl config.yml values: {e}")
 
-        # YTDL Setup
+        # Series Setup
         try:
             self.series = cfg["series"]
-        except Exception:
-            sys.exit("Error with series config.yml values.")
         except Exception as e:
-            sys.exit("Error with series config.yml values: {e}")
+            sys.exit(f"Error with series config.yml values: {e}")
 
         # Services setup - optional, provides base config for series to inherit from
         try:

--- a/test/test_root_folder_normalization.py
+++ b/test/test_root_folder_normalization.py
@@ -1,18 +1,18 @@
 """
 Unit tests for root_folder normalization logic.
-Tests the three key cases: default (unset), explicit empty, and trailing-slash stripping.
+
+These exercise the *actual* helper used by the application
+(``pathutils.normalize_root_folder``) rather than a local copy, so the test
+stays bound to the shipped code path.
 """
+import os
+import sys
 import unittest
 
+# pathutils lives in the app/ directory alongside stream_harvestarr.py.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'app'))
 
-def normalize_root_folder(raw_value):
-    """
-    Normalize root_folder value from config.
-    - Default (unset): returns /sonarr_root
-    - Explicit empty string: returns ''
-    - Trailing slash: strips it
-    """
-    return '' if raw_value == '' else raw_value.rstrip('/')
+from pathutils import normalize_root_folder, DEFAULT_ROOT_FOLDER  # noqa: E402
 
 
 class TestRootFolderNormalization(unittest.TestCase):
@@ -20,38 +20,33 @@ class TestRootFolderNormalization(unittest.TestCase):
 
     def test_default_unset_returns_sonarr_root(self):
         """Default case: unset root_folder should normalize to /sonarr_root."""
-        raw = '/sonarr_root'  # default from .get('root_folder', '/sonarr_root')
-        result = normalize_root_folder(raw)
+        # Mirrors __init__: cfg['sonarr'].get('root_folder', DEFAULT_ROOT_FOLDER)
+        result = normalize_root_folder(DEFAULT_ROOT_FOLDER)
         self.assertEqual(result, '/sonarr_root')
 
     def test_explicit_empty_string_returns_empty(self):
         """Empty string case: '' should remain ''."""
-        raw = ''
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('')
         self.assertEqual(result, '')
 
     def test_trailing_slash_stripped(self):
         """Trailing slash case: /sonarr_root/ should become /sonarr_root."""
-        raw = '/sonarr_root/'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/sonarr_root/')
         self.assertEqual(result, '/sonarr_root')
 
     def test_custom_path_with_trailing_slash_stripped(self):
         """Custom path with trailing slash should be stripped."""
-        raw = '/custom/path/'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/custom/path/')
         self.assertEqual(result, '/custom/path')
 
     def test_custom_path_without_trailing_slash_unchanged(self):
         """Custom path without trailing slash should remain unchanged."""
-        raw = '/custom/path'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/custom/path')
         self.assertEqual(result, '/custom/path')
 
     def test_multiple_trailing_slashes_all_stripped(self):
         """Multiple trailing slashes should all be stripped."""
-        raw = '/sonarr_root///'
-        result = normalize_root_folder(raw)
+        result = normalize_root_folder('/sonarr_root///')
         self.assertEqual(result, '/sonarr_root')
 
 

--- a/test/test_root_folder_normalization.py
+++ b/test/test_root_folder_normalization.py
@@ -1,0 +1,59 @@
+"""
+Unit tests for root_folder normalization logic.
+Tests the three key cases: default (unset), explicit empty, and trailing-slash stripping.
+"""
+import unittest
+
+
+def normalize_root_folder(raw_value):
+    """
+    Normalize root_folder value from config.
+    - Default (unset): returns /sonarr_root
+    - Explicit empty string: returns ''
+    - Trailing slash: strips it
+    """
+    return '' if raw_value == '' else raw_value.rstrip('/')
+
+
+class TestRootFolderNormalization(unittest.TestCase):
+    """Test cases for root_folder config normalization."""
+
+    def test_default_unset_returns_sonarr_root(self):
+        """Default case: unset root_folder should normalize to /sonarr_root."""
+        raw = '/sonarr_root'  # default from .get('root_folder', '/sonarr_root')
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '/sonarr_root')
+
+    def test_explicit_empty_string_returns_empty(self):
+        """Empty string case: '' should remain ''."""
+        raw = ''
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '')
+
+    def test_trailing_slash_stripped(self):
+        """Trailing slash case: /sonarr_root/ should become /sonarr_root."""
+        raw = '/sonarr_root/'
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '/sonarr_root')
+
+    def test_custom_path_with_trailing_slash_stripped(self):
+        """Custom path with trailing slash should be stripped."""
+        raw = '/custom/path/'
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '/custom/path')
+
+    def test_custom_path_without_trailing_slash_unchanged(self):
+        """Custom path without trailing slash should remain unchanged."""
+        raw = '/custom/path'
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '/custom/path')
+
+    def test_multiple_trailing_slashes_all_stripped(self):
+        """Multiple trailing slashes should all be stripped."""
+        raw = '/sonarr_root///'
+        result = normalize_root_folder(raw)
+        self.assertEqual(result, '/sonarr_root')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wiki/Advanced-Features.md
+++ b/wiki/Advanced-Features.md
@@ -8,6 +8,7 @@ This guide covers advanced configuration options and use cases for Stream Harves
 - [Custom Video Formats](#custom-video-formats)
 - [Subtitle Configuration](#subtitle-configuration)
 - [Time Offsets](#time-offsets)
+- [Specifying Root Folder](#specifying-root-folder)
 - [Regex Title Matching](#regex-title-matching)
 - [Playlist Handling](#playlist-handling)
 - [Services](#services)
@@ -39,6 +40,7 @@ Supported browsers: chrome, firefox, safari, edge, opera, brave
 ### Using Cookies
 
 1. Place cookie file in config directory:
+
 ```bash
 /path/to/config/
 ├── config.yml
@@ -46,6 +48,7 @@ Supported browsers: chrome, firefox, safari, edge, opera, brave
 ```
 
 2. Reference in config:
+
 ```yaml
 series:
   - title: Members Only Series
@@ -76,6 +79,7 @@ chmod 600 /path/to/config/youtube_cookies.txt
 5. Check file permissions
 
 **Example cookie file format:**
+
 ```
 # Netscape HTTP Cookie File
 .youtube.com	TRUE	/	TRUE	1234567890	COOKIE_NAME	cookie_value
@@ -88,6 +92,7 @@ YT-DLP provides powerful format selection capabilities.
 ### Format Selection Syntax
 
 Basic format string structure:
+
 ```
 [quality_filter][+][audio_filter]/[fallback]
 ```
@@ -95,41 +100,49 @@ Basic format string structure:
 ### Common Format Examples
 
 **Best quality available:**
+
 ```yaml
 format: bestvideo+bestaudio/best
 ```
 
 **1080p maximum:**
+
 ```yaml
 format: bestvideo[height<=1080]+bestaudio/best[height<=1080]
 ```
 
 **720p maximum:**
+
 ```yaml
 format: bestvideo[height<=720]+bestaudio/best[height<=720]
 ```
 
 **4K maximum:**
+
 ```yaml
 format: bestvideo[height<=2160]+bestaudio/best[height<=2160]
 ```
 
 **Specific container formats:**
+
 ```yaml
 format: bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best
 ```
 
 **Prefer webm, fallback to mp4:**
+
 ```yaml
 format: bestvideo[ext=webm]+bestaudio[ext=webm]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best
 ```
 
 **Limit file size (approximate):**
+
 ```yaml
 format: bestvideo[filesize<500M]+bestaudio/best[filesize<500M]
 ```
 
 **Prefer 60fps:**
+
 ```yaml
 format: bestvideo[fps>=60]+bestaudio/bestvideo+bestaudio/best
 ```
@@ -212,6 +225,7 @@ series:
 ### Subtitle Language Codes
 
 Common language codes:
+
 - `en` - English
 - `es` - Spanish
 - `fr` - French
@@ -229,6 +243,7 @@ Full list: [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_cod
 ### Subtitle Format
 
 Subtitles are:
+
 1. Downloaded as `.vtt` files
 2. Converted to `.srt` format
 3. Embedded in the video file
@@ -271,30 +286,35 @@ All fields are optional. Offsets are additive.
 ### Example Scenarios
 
 **Member videos release 3 days early:**
+
 ```yaml
 offset:
   days: 3
 ```
 
 **Videos release 1 week early for top-tier patrons:**
+
 ```yaml
 offset:
   weeks: 1
 ```
 
 **Content embargoed for 48 hours:**
+
 ```yaml
 offset:
   days: 2
 ```
 
 **Videos available 6 hours early:**
+
 ```yaml
 offset:
   hours: 6
 ```
 
 **Complex: 1 week + 2 days + 6 hours:**
+
 ```yaml
 offset:
   weeks: 1
@@ -305,6 +325,7 @@ offset:
 ### How Offsets Work
 
 Without offset:
+
 ```
 Episode airs: 2025-01-01 00:00:00
 Sonarr sees it: Immediately
@@ -312,6 +333,7 @@ Download attempt: 2025-01-01 00:00:00
 ```
 
 With 3-day offset:
+
 ```
 Episode airs: 2025-01-01 00:00:00
 Sonarr sees it: Immediately
@@ -319,6 +341,35 @@ Download attempt: 2025-01-04 00:00:00 (3 days later)
 ```
 
 This prevents attempting to download content that isn't available yet.
+
+## Specifying Root Folder
+
+The `root_folder` setting controls how downloaded files are saved. Downloads are saved to: `{root_folder}{sonarr_path_from_api}`.
+
+### Common scenarios:
+
+**1. Default behavior (legacy, backward compatible):**
+
+```yaml
+# Omit sonarr_root or set it explicitly:
+# root_folder: '/sonarr_root'
+```
+
+Downloads go to: `/sonarr_root{Sonarr series path}`
+
+- Example: `/sonarr_root/data/media/tv/Series/Season 1/...`
+- **Use case:** Original container setup with `-v /path/to/media:/sonarr_root`
+
+**2. Absolute Paths (used in TRaSH Guide):**
+
+```yaml
+root_folder: ''  # Empty string means use absolute paths directly
+```
+
+Downloads go directly to: `{Sonarr series path}`
+
+- Example: `/data/media/tv/Series/Season 1/...`
+- **Use case:** Following [TRaSH Guides](https://trash-guides.info/) with same absolute path mounts
 
 ## Regex Title Matching
 
@@ -444,6 +495,7 @@ Configure how playlists are processed.
 ### Playlist Order
 
 **Default behavior (reverse):**
+
 ```yaml
 series:
   - title: Series Name
@@ -452,6 +504,7 @@ series:
 ```
 
 **Newest first:**
+
 ```yaml
 series:
   - title: Series Name
@@ -462,11 +515,13 @@ series:
 ### When to Use Each
 
 **Reverse (True) - Default:**
+
 - Most web series (episodes released chronologically)
 - Archive playlists (oldest episode is #1)
 - Sequential content
 
 **Not Reversed (False):**
+
 - Playlists where newest videos are most important
 - "Latest uploads" playlists
 - Reverse-chronological content
@@ -474,17 +529,21 @@ series:
 ### Playlist vs Channel
 
 **Playlist URL:**
+
 ```yaml
 url: https://www.youtube.com/playlist?list=PLxxxxxxxx
 ```
+
 - Only includes videos in that specific playlist
 - Controlled playlist order
 - May not include all uploads
 
 **Channel URL:**
+
 ```yaml
 url: https://www.youtube.com/channel/UCxxxxxxxx
 ```
+
 - Includes all uploads to channel
 - Chronological order
 - May include videos not in specific playlists
@@ -551,16 +610,16 @@ series:
 
 All of the following can be set at service level and overridden at series level:
 
-| Key | Description |
-|-----|-------------|
-| `username` | Login username |
-| `password` | Login password |
-| `cookies_file` | Cookie file path |
-| `format` | yt-dlp format string |
+| Key                 | Description               |
+| ------------------- | ------------------------- |
+| `username`        | Login username            |
+| `password`        | Login password            |
+| `cookies_file`    | Cookie file path          |
+| `format`          | yt-dlp format string      |
 | `playlistreverse` | Playlist processing order |
-| `offset` | Air date offset |
-| `subtitles` | Subtitle configuration |
-| `regex` | Title matching patterns |
+| `offset`          | Air date offset           |
+| `subtitles`       | Subtitle configuration    |
+| `regex`           | Title matching patterns   |
 
 ## Multiple Series Management
 
@@ -569,6 +628,7 @@ Best practices for managing many series.
 ### Organization Strategies
 
 **Group by source:**
+
 ```yaml
 series:
   # YouTube Series
@@ -584,6 +644,7 @@ series:
 ```
 
 **Group by configuration type:**
+
 ```yaml
 series:
   # Standard series (no special config)
@@ -606,6 +667,7 @@ series:
 For shared credentials, subtitles, or other settings across multiple series from the same platform, use the [Services](#services) feature to avoid repetition.
 
 **Format can still be defined per-series:**
+
 ```yaml
 series:
   - title: 4K Content
@@ -622,12 +684,14 @@ series:
 With many series:
 
 1. **Increase scan interval:**
+
 ```yaml
 streamharvestarr:
     scan_interval: 5  # Check every 5 minutes instead of 1
 ```
 
 2. **Enable rate limiting:**
+
 ```yaml
 streamharvestarr:
     download_delay: 10
@@ -646,6 +710,7 @@ streamharvestarr:
 4. **Update TVDB** - Ensure episode titles match
 
 **Example maintenance script:**
+
 ```bash
 #!/bin/bash
 # Check which series have recent errors

--- a/wiki/Advanced-Features.md
+++ b/wiki/Advanced-Features.md
@@ -351,7 +351,7 @@ The `root_folder` setting controls how downloaded files are saved. Downloads are
 **1. Default behavior (legacy, backward compatible):**
 
 ```yaml
-# Omit sonarr_root or set it explicitly:
+# Omit root_folder or set it explicitly:
 # root_folder: '/sonarr_root'
 ```
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -98,6 +98,7 @@ sonarr:
     ssl: false
     # basedir: '/sonarr'  # Optional
     # version: v4         # Optional
+    # root_folder: '/'  # Optional, path prefix for downloads
 ```
 
 | Setting | Type | Required | Description |
@@ -108,6 +109,7 @@ sonarr:
 | `ssl` | boolean | Yes | Use HTTPS instead of HTTP |
 | `basedir` | string | No | Base directory if Sonarr runs behind a proxy (e.g., `/sonarr`) |
 | `version` | string | No | Set to `v4` if running Sonarr v4 beta |
+| `root_folder` | string | No | Path prefix for downloaded files (default:`/sonarr_root`). See [Advanced Features](Advanced-Features#specifying-root-folder) |
 
 ### Finding Your Sonarr API Key
 
@@ -134,21 +136,25 @@ ytdl:
 ### Format Selection Examples
 
 **1080p maximum:**
+
 ```yaml
 default_format: bestvideo[width<=1920]+bestaudio/best[width<=1920]
 ```
 
 **720p maximum:**
+
 ```yaml
 default_format: bestvideo[width<=1280]+bestaudio/best[width<=1280]
 ```
 
 **Best available quality:**
+
 ```yaml
 default_format: bestvideo+bestaudio/best
 ```
 
 **MP4 only with fallback:**
+
 ```yaml
 default_format: bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best
 ```

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -98,7 +98,7 @@ sonarr:
     ssl: false
     # basedir: '/sonarr'  # Optional
     # version: v4         # Optional
-    # root_folder: '/'  # Optional, path prefix for downloads
+    # root_folder: '/sonarr_root'  # Optional, path prefix for downloads (default: /sonarr_root)
 ```
 
 | Setting | Type | Required | Description |


### PR DESCRIPTION
## Release: root_folder support + config-parsing cleanup

Promotes `development` → `main`. Closes #137.

### ✨ Feature
- **Configurable download root (`sonarr.root_folder`)** — #140
  The download path prefix is no longer hardcoded to `/sonarr_root`.
  - Defaults to `/sonarr_root`, so **existing setups are unchanged**.
  - Set `root_folder: ''` to use Sonarr's absolute path directly — the
    TRaSH Guides / unified-hardlink layout — so containers no longer have
    to over-mount the host filesystem (e.g. `/mnt/user:/sonarr_root`).
  - Trailing slashes are normalized (`/data/` ≡ `/data`).

### 🐛 Fixes
- **Config-parsing error handlers** — #141, #140
  Removed unreachable duplicate `except` blocks in the sonarr / ytdl /
  series config setup, and fixed an error message that printed a literal
  `{e}` instead of interpolating the exception.

### ♻️ Internal
- **Test bound to shipped logic** — #142
  Extracted `normalize_root_folder()` into a new side-effect-free
  `app/pathutils.py`; the unit test now imports the real helper instead of
  a copy, so the test and the code can't silently drift.

### Compatibility
- **No breaking changes.** `/sonarr_root` remains the default; users with
  `-v /path/to/media:/sonarr_root` and no `root_folder` key are unaffected.

### Validation
- CI green on all three PRs into `development`: multi-arch build + the
  linux/amd64 YouTube-extraction smoke test.
- `root_folder` normalization unit tests: 6/6 pass against the shipped helper.

### Security
- Net-positive: reduces the filesystem exposure operators must grant the
  container; introduces no new untrusted input.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqSNrwH2dWR96cL25Y5KU5)_