### PR TITLE
ci(docker-builder): skip publish for doc-only pushes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,13 @@ on:
       - development
     tags:
       - "*"
+    # Doc-only pushes don't change the shipped image, so skip the
+    # build/publish (and, on main, the version bump + release). A push that
+    # also touches code, the Dockerfile, or workflows still builds normally.
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'wiki/**'
 
 permissions:
   contents: write        # tag + release creation


### PR DESCRIPTION
## What this does

Adds a `paths-ignore` to the **Docker Builder** publish workflow (`main.yaml`) so **documentation-only pushes don't trigger an image build/publish** — and on `main`, don't trigger a version bump + release.

### Why

`main.yaml` triggers on `push` to `development`/`main` with **no path filter**, so a doc-only change (e.g. `CLAUDE.md`, READMEs, `wiki/**`, `LICENSE`) currently:
- on `development` → rebuilds and republishes the **`dev`** image
- on `main` → **bumps the version, cuts a GitHub release, and republishes `latest`**

None of those files ship in the container, so the rebuilt image is byte-for-byte equivalent — pure wasted build plus a spurious `dev` push / empty release.

### Change

```yaml
  push:
    branches: [main, development]
    tags: ["*"]
    paths-ignore:
      - '**.md'
      - 'LICENSE'
      - 'wiki/**'
```

A push is skipped **only when every changed file matches** the ignore list. Any push that also touches code, the Dockerfile, or workflows builds and publishes exactly as before, so real releases are unaffected.

### Scope notes

- **`ci.yaml` is intentionally left unfiltered** — doc-only PRs still get the per-PR build/smoke sanity check, and this avoids the "required check never reports" branch-protection gotcha.
- `wiki/**` changes still sync to the GitHub wiki via `sync-wiki.yaml` (separate workflow); they just no longer rebuild the image.

This is the prerequisite for landing the CLAUDE.md policy PR (#144) without it kicking off a throwaway `dev` publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqSNrwH2dWR96cL25Y5KU5)_